### PR TITLE
Typescript 5.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,7 @@ astgen-macos-arm64
 astgen-macos-x64
 astgen-win-x64.exe
 astgen-linux
+astgen-linux-arm64
 astgen-macos-arm
 astgen-macos
 astgen-win.exe

--- a/index.js
+++ b/index.js
@@ -192,9 +192,20 @@ const toVueAst = (file) => {
 function createTsc(srcFiles) {
     try {
         const program = tsc.createProgram(srcFiles, {
-            target: tsc.ScriptTarget.ES6,
+            target: tsc.ScriptTarget.ES2020,
             module: tsc.ModuleKind.CommonJS,
-            allowJs: true
+            allowJs: true,
+            allowUnreachableCode: true,
+            allowUnusedLabels: true,
+            alwaysStrict: false,
+            emitDecoratorMetadata: true,
+            exactOptionalPropertyTypes: true,
+            experimentalDecorators: false,
+            ignoreDeprecations: true,
+            noStrictGenericChecks: true,
+            noUncheckedIndexedAccess: false,
+            noPropertyAccessFromIndexSignature: false,
+            removeComments: true
         });
         const typeChecker = program.getTypeChecker();
         const seenTypes = new Map();
@@ -241,7 +252,7 @@ function createTsc(srcFiles) {
             } else {
                 typeStr = safeTypeWithContextToString(typeChecker.getTypeAtLocation(node), node);
             }
-            if (typeStr !== "any") seenTypes.set(node.getStart(), typeStr);
+            if (!["any", "unknown", "any[]", "unknown[]"].includes(typeStr)) seenTypes.set(node.getStart(), typeStr);
             tsc.forEachChild(node, addType);
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joernio/astgen",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Generate JS/TS AST in json format with Babel",
   "exports": "./index.js",
   "keywords": [
@@ -14,8 +14,8 @@
   "author": "Max Leuthaeuser",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/parser": "^7.21.8",
-    "typescript": "^5.0.4",
+    "@babel/parser": "^7.22.4",
+    "typescript": "^5.1.3",
     "yargs": "^17.7.2"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13,7 +13,7 @@
 
 "@babel/helper-string-parser@^7.18.10":
   version "7.21.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.21.5.tgz#2b3eea65443c6bdc31c22d037c65f6d323b6b2bd"
+  resolved "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.21.5.tgz"
   integrity sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==
 
 "@babel/helper-validator-identifier@^7.18.6":
@@ -26,25 +26,17 @@
   resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.18.4.tgz"
   integrity sha512-FDge0dFazETFcxGw/EXzOkN8uJp0PC7Qbm+Pe9T+av2zlBpOgunFHkQPPn+eRuClU73JF+98D531UgayY89tow==
 
-"@babel/parser@^7.21.8":
-  version "7.21.8"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.21.8.tgz#642af7d0333eab9c0ad70b14ac5e76dbde7bfdf8"
-  integrity sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==
+"@babel/parser@^7.22.4":
+  version "7.22.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.4.tgz#a770e98fd785c231af9d93f6459d36770993fb32"
+  integrity sha512-VLLsx06XkEYqBtE5YGPwfSGwfrjnyPP5oiGty3S8pQLFDFLaS8VwWSIxkTXpcvr5zeYLE6+MBNl2npl/YnfofA==
 
-"@babel/types@7.19.0":
+"@babel/types@7.19.0", "@babel/types@^7.18.2":
   version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.19.0.tgz#75f21d73d73dc0351f3368d28db73465f4814600"
+  resolved "https://registry.npmjs.org/@babel/types/-/types-7.19.0.tgz"
   integrity sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==
   dependencies:
     "@babel/helper-string-parser" "^7.18.10"
-    "@babel/helper-validator-identifier" "^7.18.6"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.18.2":
-  version "7.18.9"
-  resolved "https://registry.npmjs.org/@babel/types/-/types-7.18.9.tgz"
-  integrity sha512-WwMLAg2MvJmt/rKEVQBBhIVffMmnilX4oe0sRe7iPOHIGsqpruFHHdrfj4O1CMMtgMtCU4oPafZjDPCRgO57Wg==
-  dependencies:
     "@babel/helper-validator-identifier" "^7.18.6"
     to-fast-properties "^2.0.0"
 
@@ -183,7 +175,7 @@ cliui@^7.0.2:
 
 cliui@^8.0.1:
   version "8.0.1"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  resolved "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz"
   integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
   dependencies:
     string-width "^4.2.0"
@@ -232,7 +224,7 @@ debug@4:
 
 decompress-response@^6.0.0:
   version "6.0.0"
-  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
+  resolved "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz"
   integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
   dependencies:
     mimic-response "^3.1.0"
@@ -244,7 +236,7 @@ deep-extend@^0.6.0:
 
 detect-libc@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.1.tgz#e1897aa88fa6ad197862937fbc0441ef352ee0cd"
+  resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz"
   integrity sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==
 
 dir-glob@^3.0.1:
@@ -486,7 +478,7 @@ micromatch@^4.0.4:
 
 mimic-response@^3.1.0:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
+  resolved "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz"
   integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
 
 minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.6:
@@ -519,7 +511,7 @@ napi-build-utils@^1.0.1:
 
 node-abi@^3.3.0:
   version "3.40.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.40.0.tgz#51d8ed44534f70ff1357dfbc3a89717b1ceac1b4"
+  resolved "https://registry.npmjs.org/node-abi/-/node-abi-3.40.0.tgz"
   integrity sha512-zNy02qivjjRosswoYmPi8hIKJRr8MpQyeKT6qlcq/OnOgA3Rhoae+IYOqsM9V5+JnHWmxKnWOT2GxvtqdtOCXA==
   dependencies:
     semver "^7.3.5"
@@ -579,7 +571,7 @@ pkg-fetch@3.4.2:
 
 pkg@^5.8.1:
   version "5.8.1"
-  resolved "https://registry.yarnpkg.com/pkg/-/pkg-5.8.1.tgz#862020f3c0575638ef7d1146f951a54d65ddc984"
+  resolved "https://registry.npmjs.org/pkg/-/pkg-5.8.1.tgz"
   integrity sha512-CjBWtFStCfIiT4Bde9QpJy0KeH19jCfwZRJqHFDFXfhUklCx8JoFmMj3wgnEYIwGmZVNkhsStPHEOnrtrQhEXA==
   dependencies:
     "@babel/generator" "7.18.2"
@@ -599,7 +591,7 @@ pkg@^5.8.1:
 
 prebuild-install@7.1.1:
   version "7.1.1"
-  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.1.tgz#de97d5b34a70a0c81334fd24641f2a1702352e45"
+  resolved "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz"
   integrity sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==
   dependencies:
     detect-libc "^2.0.0"
@@ -696,12 +688,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-safe-buffer@^5.0.1, safe-buffer@~5.2.0:
-  version "5.2.1"
-  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
-
-safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -732,7 +719,7 @@ simple-concat@^1.0.0:
 
 simple-get@^4.0.0:
   version "4.0.1"
-  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.1.tgz#4a39db549287c979d352112fa03fd99fd6bc3543"
+  resolved "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz"
   integrity sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
   dependencies:
     decompress-response "^6.0.0"
@@ -760,14 +747,7 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
-
-string_decoder@~1.1.1:
+string_decoder@^1.1.1, string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
@@ -843,10 +823,10 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-typescript@^5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
-  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+typescript@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.3.tgz#8d84219244a6b40b6fb2b33cc1c062f715b9e826"
+  integrity sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==
 
 universalify@^2.0.0:
   version "2.0.0"
@@ -909,7 +889,7 @@ yargs-parser@^20.2.2:
 
 yargs-parser@^21.1.1:
   version "21.1.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
 yargs@^16.2.0:
@@ -927,7 +907,7 @@ yargs@^16.2.0:
 
 yargs@^17.7.2:
   version "17.7.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
   dependencies:
     cliui "^8.0.1"


### PR DESCRIPTION
This brings typescript 5.1 and bumps up the target to ES2020. Also cleaned out some settings.

For juice-shop, it reduces the unwanted `any` and `unknown` and brings some new types.

```
❯ diff /tmp/ast_out /tmp/ast_out2
Common subdirectories: /tmp/ast_out/data and /tmp/ast_out2/data
Common subdirectories: /tmp/ast_out/frontend and /tmp/ast_out2/frontend
diff --color /tmp/ast_out/Gruntfile.js.typemap /tmp/ast_out2/Gruntfile.js.typemap
26d25
<   "659": "any[]",
31d29
<   "711": "any[]",
Common subdirectories: /tmp/ast_out/lib and /tmp/ast_out2/lib
Common subdirectories: /tmp/ast_out/models and /tmp/ast_out2/models
Common subdirectories: /tmp/ast_out/routes and /tmp/ast_out2/routes
Common subdirectories: /tmp/ast_out/rsn and /tmp/ast_out2/rsn
diff --color /tmp/ast_out/server.ts.typemap /tmp/ast_out2/server.ts.typemap
204c204,206
<   "8389": "any[]",
---
>   "8389": "(separator?: string) => string",
>   "8393": "Set<unknown>",
>   "8397": "SetConstructor",
629,630d630
<   "22489": "unknown",
<   "22494": "unknown",
633d632
<   "22530": "unknown",
645d643
<   "23002": "any[]",
657c655
<   "23171": "(str: string, element: string) => any",
---
>   "23171": "(str: string, element: string) => boolean",
722d719
<   "24361": "any[]",
764,765d760
<   "24986": "any[]",
<   "24996": "any[]",
770d764
<   "25061": "any[]",
774d767
<   "25103": "any[]",
778d770
<   "25137": "any[]",
781d772
<   "25173": "any[]",
785d775
<   "25214": "any[]",
967c957,958
<   "31459": "(o: object) => string[]",
---
>   "31459": "{ (o: object): string[]; (o: {}): string[]; }",
>   "31482": "(searchElement: string, fromIndex?: number) => boolean",
971c962
<   "31552": "(o: object) => string[]",
---
>   "31552": "{ (o: object): string[]; (o: {}): string[]; }",
980c971
<   "31745": "(o: object) => string[]",
---
>   "31745": "{ (o: object): string[]; (o: {}): string[]; }",
Common subdirectories: /tmp/ast_out/views and /tmp/ast_out2/views
```