### PR TITLE
Skip the minified files from parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ const IGNORE_DIRS = [
     "build",
 ];
 
-const IGNORE_FILE_PATTERN = new RegExp("(conf|test|spec|\\.d)\\.(js|ts|jsx|tsx)$", "i");
+const IGNORE_FILE_PATTERN = new RegExp("(conf|test|spec|min|\\.d)\\.(js|ts|jsx|tsx)$", "i");
 
 const getAllFiles = (dir, extn, files, result, regex) => {
     files = files || fs.readdirSync(dir);


### PR DESCRIPTION
- Some repos contains the unnecessary minifieds js files which we should avoid to parse.
- Updated exclude rule to remove the minified files