### PR TITLE
Fixed IGNORE_FILE_PATTERN

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ const IGNORE_DIRS = [
     "build",
 ];
 
-const IGNORE_FILE_PATTERN = new RegExp("(conf|test|spec|min|\\.d)\\.(js|ts|jsx|tsx)$", "i");
+const IGNORE_FILE_PATTERN = new RegExp("(conf|test|spec|[.-]min|\\.d)\\.(js|ts|jsx|tsx)$", "i");
 
 const getAllFiles = (dir, extn, files, result, regex) => {
     files = files || fs.readdirSync(dir);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joernio/astgen",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Generate JS/TS AST in json format with Babel",
   "exports": "./index.js",
   "keywords": [


### PR DESCRIPTION
Otherwise we would ignore all files ending with `min.ext`, e.g., `admin.ext`.