### PR TITLE
Add regression test harness

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -1,0 +1,71 @@
+name: regression
+
+on:
+  pull_request:
+
+jobs:
+  regression:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'yarn'
+
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Build PR version
+        run: |
+          yarn install
+          yarn build
+          cp -r dist dist-pr
+
+      - name: Build base version
+        run: |
+          set -e
+          git worktree add ../astgen-base "origin/${{ github.base_ref }}"
+          (cd ../astgen-base && yarn install && yarn build)
+          cp -r ../astgen-base/dist dist-base
+          git worktree remove --force ../astgen-base
+
+      - name: Run regression script
+        run: |
+          python3 scripts/regression.py --base-dist dist-base --pr-dist dist-pr --pr-number "${{ github.event.pull_request.number }}" > regression-report.md
+
+      - name: Post PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('regression-report.md', 'utf8');
+            const marker = '<!-- astgen-regression -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,9 @@ typings/
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 
+# pycache
+__pycache__
+
 # Next.js build output
 .next
 
@@ -122,3 +125,6 @@ astgen-linux-arm64~
 astgen-macos-arm
 astgen-macos
 astgen-win.exe
+
+# Git worktrees
+.worktrees/

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "scripts": {
     "test": "jest --silent --config=jest.config.js",
     "build": "tsc --build",
-    "binary": "pkg . --options max-old-space-size=8192 --no-bytecode --no-native-build --compress GZip --targets node18-linux-x64,node18-linux-arm64,node18-macos-x64,node18-win-x64,node18-macos-arm64"
+    "binary": "pkg . --options max-old-space-size=8192 --no-bytecode --no-native-build --compress GZip --targets node18-linux-x64,node18-linux-arm64,node18-macos-x64,node18-win-x64,node18-macos-arm64",
+    "regression": "python3 scripts/regression-local.py"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/scripts/regression-local.py
+++ b/scripts/regression-local.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+Local regression runner for astgen.
+
+Builds the current working tree (PR version) and the main branch (base version),
+then runs the regression harness and prints the Markdown report to stdout.
+
+Usage:
+    python3 scripts/regression-local.py [--base-branch BRANCH]
+
+Or via yarn:
+    yarn regression
+"""
+
+import argparse
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+
+
+def run(cmd: list, cwd: str = None, capture: bool = False) -> subprocess.CompletedProcess:
+    kwargs = {"cwd": cwd, "check": True}
+    if capture:
+        kwargs["stdout"] = subprocess.PIPE
+        kwargs["stderr"] = subprocess.PIPE
+    return subprocess.run(cmd, **kwargs)
+
+
+def find_repo_root() -> pathlib.Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    return pathlib.Path(result.stdout.decode().strip())
+
+
+def current_branch(repo_root: pathlib.Path) -> str:
+    result = subprocess.run(
+        ["git", "branch", "--show-current"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+        cwd=str(repo_root),
+    )
+    return result.stdout.decode().strip()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Build current branch and base branch, then run regression harness.",
+    )
+    parser.add_argument(
+        "--base-branch",
+        default="main",
+        metavar="BRANCH",
+        help="Base branch to compare against (default: main).",
+    )
+    args = parser.parse_args()
+
+    repo_root = find_repo_root()
+    branch = current_branch(repo_root)
+    scripts_dir = repo_root / "scripts"
+    regression_script = scripts_dir / "regression.py"
+
+    if not regression_script.exists():
+        print(f"ERROR: {regression_script} not found.", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"[local-regression] Current branch: {branch}", file=sys.stderr)
+    print(f"[local-regression] Base branch:    {args.base_branch}", file=sys.stderr)
+
+    # Keep dist-pr and dist-base inside the repo root so that Node can resolve
+    # node_modules by walking up the directory tree (same as the CI workflow).
+    worktree_path = str(repo_root / ".worktrees" / "regression-base")
+    dist_pr = str(repo_root / "dist-pr")
+    dist_base = str(repo_root / "dist-base")
+
+    try:
+        # Build PR version (current working tree)
+        print("[local-regression] Building PR version (current tree)...", file=sys.stderr)
+        run(["yarn", "install"], cwd=str(repo_root))
+        run(["yarn", "build"], cwd=str(repo_root))
+        if os.path.exists(dist_pr):
+            shutil.rmtree(dist_pr)
+        shutil.copytree(str(repo_root / "dist"), dist_pr)
+
+        # Build base version via git worktree
+        print(f"[local-regression] Checking out {args.base_branch} into worktree...", file=sys.stderr)
+        run(
+            ["git", "worktree", "add", worktree_path, args.base_branch],
+            cwd=str(repo_root),
+        )
+        print("[local-regression] Building base version...", file=sys.stderr)
+        run(["yarn", "install"], cwd=worktree_path)
+        run(["yarn", "build"], cwd=worktree_path)
+        if os.path.exists(dist_base):
+            shutil.rmtree(dist_base)
+        shutil.copytree(os.path.join(worktree_path, "dist"), dist_base)
+
+        # Remove worktree before running regression
+        run(["git", "worktree", "remove", worktree_path], cwd=str(repo_root))
+
+        # Run regression script — output goes directly to stdout
+        print("[local-regression] Running regression harness...\n", file=sys.stderr)
+        subprocess.run(
+            [sys.executable, str(regression_script), "--base-dist", dist_base, "--pr-dist", dist_pr],
+            check=False,
+        )
+
+    finally:
+        shutil.rmtree(dist_pr, ignore_errors=True)
+        shutil.rmtree(dist_base, ignore_errors=True)
+        # Clean up worktree registration if it still exists (e.g. on early failure)
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", worktree_path],
+            cwd=str(repo_root),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/regression.py
+++ b/scripts/regression.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python3
+"""
+Regression harness for astgen.
+
+Usage:
+    python3 scripts/regression.py --base-dist ./dist-base --pr-dist ./dist-pr
+"""
+
+import argparse
+import difflib
+import filecmp
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+
+# ---------------------------------------------------------------------------
+# Corpus definitions
+# ---------------------------------------------------------------------------
+
+CORPORA = [
+    {
+        "name": "typeorm",
+        "label": "typeorm/typeorm@0.3.21",
+        "clone_url": "https://github.com/typeorm/typeorm.git",
+        "tag": "0.3.21",
+        "input_subdir": "src",  # relative to clone root; empty string means clone root
+    },
+    {
+        "name": "fastify",
+        "label": "fastify/fastify@v5.3.3",
+        "clone_url": "https://github.com/fastify/fastify.git",
+        "tag": "v5.3.3",
+        "input_subdir": "",  # use repo root
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def human_size(n_bytes: int) -> str:
+    """Return a human-readable file size string."""
+    for unit in ("B", "KB", "MB", "GB"):
+        if n_bytes < 1024.0 or unit == "GB":
+            return f"{n_bytes:.1f} {unit}"
+        n_bytes /= 1024.0
+    return f"{n_bytes:.1f} GB"  # unreachable but makes type checkers happy
+
+
+def pct_delta(base: float, pr: float) -> str:
+    """Return a signed percentage delta string."""
+    if base == 0:
+        return "+0.0%" if pr == 0 else "+∞%"
+    delta = (pr - base) / base * 100.0
+    sign = "+" if delta >= 0 else ""
+    return f"{sign}{delta:.1f}%"
+
+
+def signed_int(delta: int) -> str:
+    """Return a signed integer string."""
+    if delta > 0:
+        return f"+{delta}"
+    return str(delta)
+
+
+def collect_metrics(out_dir: pathlib.Path) -> dict:
+    """Walk out_dir and collect file counts / sizes."""
+    json_count = 0
+    json_size = 0
+    typemap_count = 0
+    typemap_size = 0
+
+    if out_dir.exists():
+        for entry in out_dir.rglob("*"):
+            if entry.is_file():
+                size = entry.stat().st_size
+                if entry.suffix == ".json":
+                    json_count += 1
+                    json_size += size
+                elif entry.name.endswith(".typemap"):
+                    typemap_count += 1
+                    typemap_size += size
+
+    return {
+        "json_count": json_count,
+        "json_size": json_size,
+        "typemap_count": typemap_count,
+        "typemap_size": typemap_size,
+    }
+
+
+def run_astgen(dist_dir: str, input_dir: str, output_dir: str) -> tuple[bool, float]:
+    """
+    Run astgen and return (success, elapsed_seconds).
+    Stdout/stderr are captured and not printed to the terminal.
+    """
+    astgen_js = os.path.join(dist_dir, "astgen.js")
+    cmd = ["node", astgen_js, "-i", input_dir, "-o", output_dir, "-t", "ts"]
+
+    os.makedirs(output_dir, exist_ok=True)
+    t0 = time.monotonic()
+    try:
+        result = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        elapsed = time.monotonic() - t0
+        if result.returncode != 0:
+            print(
+                f"WARNING: astgen exited {result.returncode} for {output_dir}\n"
+                f"  stderr: {result.stderr.decode(errors='replace')[:500]}",
+                file=sys.stderr,
+            )
+            return False, elapsed
+        return True, elapsed
+    except Exception as exc:
+        elapsed = time.monotonic() - t0
+        print(f"WARNING: failed to run astgen for {output_dir}: {exc}", file=sys.stderr)
+        return False, elapsed
+
+
+def compare_outputs(base_dir: pathlib.Path, pr_dir: pathlib.Path) -> dict:
+    """
+    Compare two output directories byte-by-byte.
+
+    Returns:
+        {
+            "only_in_base": [relative_path, ...],
+            "only_in_pr": [relative_path, ...],
+            "ast_diffs": [(rel_path, unified_diff_lines), ...],
+            "typemap_diffs": [(rel_path, unified_diff_lines), ...],
+        }
+    """
+    only_in_base = []
+    only_in_pr = []
+    ast_diffs = []
+    typemap_diffs = []
+
+    # Build sets of relative paths
+    base_files: dict[str, pathlib.Path] = {}
+    pr_files: dict[str, pathlib.Path] = {}
+
+    if base_dir.exists():
+        for p in base_dir.rglob("*"):
+            if p.is_file():
+                rel = str(p.relative_to(base_dir))
+                base_files[rel] = p
+
+    if pr_dir.exists():
+        for p in pr_dir.rglob("*"):
+            if p.is_file():
+                rel = str(p.relative_to(pr_dir))
+                pr_files[rel] = p
+
+    base_set = set(base_files)
+    pr_set = set(pr_files)
+
+    only_in_base = sorted(base_set - pr_set)
+    only_in_pr = sorted(pr_set - base_set)
+
+    for rel in sorted(base_set & pr_set):
+        bp = base_files[rel]
+        pp = pr_files[rel]
+        if bp.stat().st_size == pp.stat().st_size and filecmp.cmp(str(bp), str(pp), shallow=False):
+            continue
+        # Files differ — generate unified diff
+        try:
+            base_text = bp.read_text(errors="replace").splitlines(keepends=True)
+            pr_text = pp.read_text(errors="replace").splitlines(keepends=True)
+        except Exception:
+            base_text = []
+            pr_text = []
+
+        diff_lines = list(
+            difflib.unified_diff(
+                base_text,
+                pr_text,
+                fromfile=f"out-base/{rel}",
+                tofile=f"out-pr/{rel}",
+            )
+        )
+
+        if rel.endswith(".typemap"):
+            typemap_diffs.append((rel, diff_lines))
+        elif rel.endswith(".json"):
+            ast_diffs.append((rel, diff_lines))
+
+    return {
+        "only_in_base": only_in_base,
+        "only_in_pr": only_in_pr,
+        "ast_diffs": ast_diffs,
+        "typemap_diffs": typemap_diffs,
+    }
+
+
+def build_diff_details(diffs: list, kind: str, max_total_lines: int = 200) -> str:
+    """
+    Render a collapsible <details> block with truncated unified diffs.
+    kind is 'AST' or 'typemap'.
+    """
+    n = len(diffs)
+    if n == 0:
+        return ""
+
+    lines_used = 0
+    diff_text_parts = []
+
+    for rel, diff_lines in diffs:
+        if lines_used >= max_total_lines:
+            break
+        chunk = diff_lines[: max_total_lines - lines_used]
+        lines_used += len(chunk)
+        diff_text_parts.append("".join(chunk))
+        if lines_used >= max_total_lines:
+            diff_text_parts.append("\n... (truncated)\n")
+
+    inner = "".join(diff_text_parts)
+    return (
+        f"<details><summary>{n} {kind} diffs</summary>\n\n"
+        f"```diff\n{inner}```\n\n"
+        f"</details>\n"
+    )
+
+
+def format_table_row(metric: str, base_val: str, pr_val: str, delta: str) -> str:
+    return f"| {metric:<24} | {base_val:>11} | {pr_val:>8} | {delta:>8} |"
+
+
+def render_corpus_section(name: str, label: str, result: dict, pr_label: str = "PR") -> str:
+    """Render the Markdown section for one corpus."""
+    bm = result["base_metrics"]
+    pm = result["pr_metrics"]
+    bt = result["base_time"]
+    pt = result["pr_time"]
+    cmp = result["comparison"]
+
+    ast_diff_count = len(cmp["ast_diffs"])
+    typemap_diff_count = len(cmp["typemap_diffs"])
+
+    rows = [
+        format_table_row(
+            "AST files generated",
+            str(bm["json_count"]),
+            str(pm["json_count"]),
+            signed_int(pm["json_count"] - bm["json_count"]),
+        ),
+        format_table_row(
+            "Typemap files generated",
+            str(bm["typemap_count"]),
+            str(pm["typemap_count"]),
+            signed_int(pm["typemap_count"] - bm["typemap_count"]),
+        ),
+        format_table_row(
+            "Total AST size",
+            human_size(bm["json_size"]),
+            human_size(pm["json_size"]),
+            pct_delta(bm["json_size"], pm["json_size"]),
+        ),
+        format_table_row(
+            "Total typemap size",
+            human_size(bm["typemap_size"]),
+            human_size(pm["typemap_size"]),
+            pct_delta(bm["typemap_size"], pm["typemap_size"]),
+        ),
+        format_table_row(
+            "Wall-clock time",
+            f"{bt:.1f} s",
+            f"{pt:.1f} s",
+            pct_delta(bt, pt),
+        ),
+        format_table_row(
+            "Files with AST diffs",
+            "—",
+            str(ast_diff_count),
+            "",
+        ),
+        format_table_row(
+            "Files with typemap diffs",
+            "—",
+            str(typemap_diff_count),
+            "",
+        ),
+    ]
+
+    header = (
+        f"### {name} ({label})\n\n"
+        f"| {'Metric':<24} | {'base (main)':>11} | {pr_label:>8} | {'Delta':>8} |\n"
+        f"|{'-'*26}|{'-'*13}|{'-'*10}|{'-'*10}|"
+    )
+
+    table = header + "\n" + "\n".join(rows) + "\n"
+
+    ast_details = build_diff_details(cmp["ast_diffs"], "AST")
+    typemap_details = build_diff_details(cmp["typemap_diffs"], "typemap")
+
+    parts = [table]
+    if ast_details:
+        parts.append(ast_details)
+    if typemap_details:
+        parts.append(typemap_details)
+
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Regression harness for astgen: compare base vs PR output across benchmark corpora.",
+    )
+    parser.add_argument(
+        "--base-dist",
+        required=True,
+        metavar="PATH",
+        help="Path to the compiled base branch dist/ directory.",
+    )
+    parser.add_argument(
+        "--pr-dist",
+        required=True,
+        metavar="PATH",
+        help="Path to the compiled PR branch dist/ directory.",
+    )
+    parser.add_argument(
+        "--pr-number",
+        default=None,
+        metavar="N",
+        help="PR number to display in the report header (e.g. 42).",
+    )
+    args = parser.parse_args()
+
+    base_dist = os.path.abspath(args.base_dist)
+    pr_dist = os.path.abspath(args.pr_dist)
+    pr_label = f"PR (#{args.pr_number})" if args.pr_number else "PR"
+
+    tmpdir = tempfile.mkdtemp(prefix="astgen-regression-")
+
+    corpus_results = []
+
+    try:
+        for corpus in CORPORA:
+            name = corpus["name"]
+            label = corpus["label"]
+            clone_url = corpus["clone_url"]
+            tag = corpus["tag"]
+            input_subdir = corpus["input_subdir"]
+
+            print(f"[regression] Cloning {label} ...", file=sys.stderr)
+            clone_dir = os.path.join(tmpdir, f"corpus-{name}")
+            clone_cmd = [
+                "git", "clone", "--depth", "1", "--branch", tag, clone_url, clone_dir,
+            ]
+            try:
+                subprocess.run(
+                    clone_cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    check=True,
+                )
+            except subprocess.CalledProcessError as exc:
+                print(
+                    f"WARNING: failed to clone {clone_url}: "
+                    f"{exc.stderr.decode(errors='replace')[:500]}",
+                    file=sys.stderr,
+                )
+                corpus_results.append({
+                    "name": name,
+                    "label": f"{label} [CLONE FAILED]",
+                    "base_metrics": {"json_count": 0, "json_size": 0, "typemap_count": 0, "typemap_size": 0},
+                    "pr_metrics": {"json_count": 0, "json_size": 0, "typemap_count": 0, "typemap_size": 0},
+                    "base_time": 0.0,
+                    "pr_time": 0.0,
+                    "comparison": {"only_in_base": [], "only_in_pr": [], "ast_diffs": [], "typemap_diffs": []},
+                })
+                continue
+
+            if input_subdir:
+                input_dir = os.path.join(clone_dir, input_subdir)
+            else:
+                input_dir = clone_dir
+
+            out_base = os.path.join(tmpdir, f"out-base-{name}")
+            out_pr = os.path.join(tmpdir, f"out-pr-{name}")
+
+            print(f"[regression] Running base astgen on {name} ...", file=sys.stderr)
+            _base_ok, base_time = run_astgen(base_dist, input_dir, out_base)
+
+            print(f"[regression] Running PR astgen on {name} ...", file=sys.stderr)
+            _pr_ok, pr_time = run_astgen(pr_dist, input_dir, out_pr)
+
+            base_metrics = collect_metrics(pathlib.Path(out_base))
+            pr_metrics = collect_metrics(pathlib.Path(out_pr))
+
+            print(f"[regression] Comparing outputs for {name} ...", file=sys.stderr)
+            comparison = compare_outputs(pathlib.Path(out_base), pathlib.Path(out_pr))
+
+            corpus_results.append({
+                "name": name,
+                "label": label,
+                "base_metrics": base_metrics,
+                "pr_metrics": pr_metrics,
+                "base_time": base_time,
+                "pr_time": pr_time,
+                "comparison": comparison,
+            })
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+    # Build report
+    report_parts = [
+        "<!-- astgen-regression -->",
+        "## astgen Regression Report",
+        "",
+    ]
+
+    for result in corpus_results:
+        section = render_corpus_section(result["name"], result["label"], result, pr_label)
+        report_parts.append(section)
+        report_parts.append("")
+
+    print("\n".join(report_parts))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:
+        print(f"WARNING: regression harness encountered an unexpected error: {exc}", file=sys.stderr)
+        import traceback
+        traceback.print_exc(file=sys.stderr)
+    sys.exit(0)


### PR DESCRIPTION
Adds an automated regression harness that compares AST and typemap output between two astgen builds (base branch vs PR) across two pinned benchmark corpora (typeorm 0.3.21 and fastify v5.3.3).

- `scripts/regression.py`: stdlib-only Python script that clones both corpora, runs astgen against each, byte-compares outputs, and prints a Markdown report with summary tables and unified diffs to stdout. Always exits 0.
- `scripts/regression-local.py`: local runner that builds the current branch and main (via git worktree) and invokes regression.py. Available as `yarn regression`.
- `.github/workflows/regression.yml`: GitHub Actions workflow triggered on pull_request. Builds both versions, runs the harness, and posts/updates a single PR comment (identified by an HTML marker to avoid spam on force-pushes).