### PR TITLE
Add guard for large/generated files

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,30 @@ yarn test
 
 This will use `jest` with `ts-jest` to run the tests in `test/`.
 
+## Regression Testing
+
+The regression harness compares AST and type-map output between two versions of astgen (base branch vs. PR) across two real-world TypeScript corpora: [typeorm@0.3.21](https://github.com/typeorm/typeorm) and [fastify@v5.3.3](https://github.com/fastify/fastify).
+
+**Run locally** (compares current branch against `main`):
+
+```bash
+yarn regression
+```
+
+To compare against a different base branch:
+
+```bash
+python3 scripts/regression-local.py --base-branch <branch>
+```
+
+The script builds both versions, clones the corpora, runs astgen on each, and prints a Markdown report to stdout showing:
+
+- AST and typemap file counts and total sizes
+- Wall-clock execution time
+- Per-file content diffs (collapsible, truncated to 200 lines)
+
+**CI:** The regression workflow runs automatically on every pull request (`.github/workflows/regression.yml`) and posts or updates a comment on the PR with the full report.
+
 ## Getting Help
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joernio/astgen",
-  "version": "3.37.0",
+  "version": "3.38.0",
   "description": "Generate JS/TS AST in json format with Babel",
   "exports": "./index.js",
   "keywords": [

--- a/src/Defaults.ts
+++ b/src/Defaults.ts
@@ -37,6 +37,8 @@ export const IGNORE_FILE_PATTERN: RegExp =
     new RegExp("(chunk-vendors|app~|mock|e2e|conf|test|spec|[.-]min|\\.d)\\.(js|jsx|cjs|mjs|xsjs|xsjslib|ts|tsx)$", "i")
 
 export const MAX_LOC_IN_FILE: number = 50000
+export const MAX_FILE_SIZE_BYTES: number = 5 * 1024 * 1024
+export const MAX_LINE_LENGTH: number = 10_000
 
 export const BABEL_PARSER_OPTIONS: babelParser.ParserOptions = {
     sourceType: "unambiguous",

--- a/src/FileUtils.ts
+++ b/src/FileUtils.ts
@@ -6,15 +6,6 @@ import * as fs from "node:fs"
 import nReadlines from "n-readlines"
 import * as path from "node:path"
 
-function countFileLines(filePath: string): number {
-    const broadbandLines = new nReadlines(filePath)
-    let lineNumber = 1
-    while (broadbandLines.next()) {
-        lineNumber++
-    }
-    return lineNumber
-}
-
 function dirIsInIgnorePath(options: Options, fullPath: string, ignorePath: string): boolean {
     if (path.isAbsolute(ignorePath)) {
         return fullPath.startsWith(ignorePath)
@@ -49,10 +40,28 @@ function isEmscripten(fileWithDir: string): boolean {
     return false
 }
 
-function isTooLarge(fileWithDir: string): boolean {
-    if (countFileLines(fileWithDir) > Defaults.MAX_LOC_IN_FILE) {
-        console.warn(fileWithDir, "more than", Defaults.MAX_LOC_IN_FILE, "lines of code")
+function isTooBig(fileWithDir: string): boolean {
+    if (fs.statSync(fileWithDir).size > Defaults.MAX_FILE_SIZE_BYTES) {
+        console.warn(fileWithDir, "exceeds maximum file size of", Defaults.MAX_FILE_SIZE_BYTES, "bytes")
         return true
+    }
+    return false
+}
+
+function isTooLargeOrHasLongLines(fileWithDir: string): boolean {
+    const lines = new nReadlines(fileWithDir)
+    let lineNumber = 0
+    let line: Buffer | false
+    while ((line = lines.next()) !== false) {
+        lineNumber++
+        if (line.length > Defaults.MAX_LINE_LENGTH) {
+            console.warn(fileWithDir, "line", lineNumber, "exceeds", Defaults.MAX_LINE_LENGTH, "bytes")
+            return true
+        }
+        if (lineNumber > Defaults.MAX_LOC_IN_FILE) {
+            console.warn(fileWithDir, "more than", Defaults.MAX_LOC_IN_FILE, "lines of code")
+            return true
+        }
     }
     return false
 }
@@ -64,8 +73,9 @@ function ignoreFile(options: Options, fileName: string, fullPath: string, extens
         Defaults.IGNORE_FILE_PATTERN.test(fileName) ||
         options["exclude-file"].some((e: string) => fileIsInIgnorePath(options, fullPath, e)) ||
         options["exclude-regex"]?.test(fullPath) ||
-        isEmscripten(fullPath) ||
-        isTooLarge(fullPath)
+        isTooBig(fullPath) ||
+        isTooLargeOrHasLongLines(fullPath) ||
+        isEmscripten(fullPath)
 }
 
 /**

--- a/test/astgen.test.ts
+++ b/test/astgen.test.ts
@@ -155,4 +155,42 @@ describe('astgen basic functionality', () => {
         })
     })
 
+    it('should skip files with more than 50000 lines', async () => {
+        const lines = Array(50001).fill('const x = 1;').join('\n')
+
+        await setupTestFixture(lines, "huge.ts", {}, (tmpDir: string, testFile: string) => {
+            const outFile = path.join(tmpDir, "ast_out", "huge.ts.json")
+            expect(fs.existsSync(outFile)).toBe(false)
+        })
+    })
+
+    it('should skip files with a line longer than 10000 bytes', async () => {
+        const longLine = 'const x = "' + 'a'.repeat(10001) + '";'
+        const code = `const y = 1;\n${longLine}\nconst z = 2;`
+
+        await setupTestFixture(code, "longline.ts", {}, (tmpDir: string, testFile: string) => {
+            const outFile = path.join(tmpDir, "ast_out", "longline.ts.json")
+            expect(fs.existsSync(outFile)).toBe(false)
+        })
+    })
+
+    it('should skip files larger than 5MB', async () => {
+        const bigContent = 'x'.repeat(5 * 1024 * 1024 + 1)
+
+        await setupTestFixture(bigContent, "huge.ts", {}, (tmpDir: string, testFile: string) => {
+            const outFile = path.join(tmpDir, "ast_out", "huge.ts.json")
+            expect(fs.existsSync(outFile)).toBe(false)
+        })
+    })
+
+    it('should process files just under all size thresholds', async () => {
+        const normalLine = 'const x = "' + 'a'.repeat(9980) + '";'
+        const code = `${normalLine}\nconst y = 1;`
+
+        await setupTestFixture(code, "borderline.ts", {}, (tmpDir: string, testFile: string) => {
+            const outFile = path.join(tmpDir, "ast_out", "borderline.ts.json")
+            expect(fs.existsSync(outFile)).toBe(true)
+        })
+    })
+
 })


### PR DESCRIPTION
- Prevents OOM when scanning files that have few but extremely long lines.
- Adds file size (5 MB), line count (50K), and line length (10K bytes) guards in cheapest-first order, ensuring isEmscripten never reads an oversized file.