### PR TITLE
Address OOM issues on large JS/TS projects

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Build base version
         run: |
           set -e
+          git fetch origin ${{ github.base_ref }}
           git worktree add ../astgen-base "origin/${{ github.base_ref }}"
           (cd ../astgen-base && yarn install && yarn build)
           cp -r ../astgen-base/dist dist-base
@@ -39,14 +40,32 @@ jobs:
 
       - name: Run regression script
         run: |
-          python3 scripts/regression.py --base-dist dist-base --pr-dist dist-pr --pr-number "${{ github.event.pull_request.number }}" > regression-report.md
+          BASE_SHA=$(git rev-parse --short "origin/${{ github.base_ref }}")
+          PR_SHA=$(git rev-parse --short HEAD)
+          python3 scripts/regression.py \
+            --base-dist dist-base \
+            --pr-dist dist-pr \
+            --pr-number "${{ github.event.pull_request.number }}" \
+            --base-ref "${{ github.base_ref }} @ ${BASE_SHA}" \
+            --pr-ref "${{ github.head_ref }} @ ${PR_SHA}" \
+            --output-diffs regression-diffs \
+            > regression-report.md
+
+      - name: Upload diff artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: regression-diffs
+          path: regression-diffs/
+          if-no-files-found: ignore
 
       - name: Post PR comment
         uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
-            const body = fs.readFileSync('regression-report.md', 'utf8');
+            let body = fs.readFileSync('regression-report.md', 'utf8');
+            const runUrl = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
+            body += `\n\n---\n📎 Full diff files available as [workflow artifacts](${runUrl}).`;
             const marker = '<!-- astgen-regression -->';
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joernio/astgen",
-  "version": "3.38.0",
+  "version": "3.39.0",
   "description": "Generate JS/TS AST in json format with Babel",
   "exports": "./index.js",
   "keywords": [

--- a/scripts/regression-local.py
+++ b/scripts/regression-local.py
@@ -49,6 +49,17 @@ def current_branch(repo_root: pathlib.Path) -> str:
     return result.stdout.decode().strip()
 
 
+def git_short_sha(repo_root: pathlib.Path, ref: str) -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "--short", ref],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+        cwd=str(repo_root),
+    )
+    return result.stdout.decode().strip()
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Build current branch and base branch, then run regression harness.",
@@ -70,7 +81,8 @@ def main() -> None:
         print(f"ERROR: {regression_script} not found.", file=sys.stderr)
         sys.exit(1)
 
-    print(f"[local-regression] Current branch: {branch}", file=sys.stderr)
+    pr_sha = git_short_sha(repo_root, "HEAD")
+    print(f"[local-regression] Current branch: {branch} @ {pr_sha}", file=sys.stderr)
     print(f"[local-regression] Base branch:    {args.base_branch}", file=sys.stderr)
 
     # Keep dist-pr and dist-base inside the repo root so that Node can resolve
@@ -89,9 +101,12 @@ def main() -> None:
         shutil.copytree(str(repo_root / "dist"), dist_pr)
 
         # Build base version via git worktree
-        print(f"[local-regression] Checking out {args.base_branch} into worktree...", file=sys.stderr)
+        print(f"[local-regression] Fetching {args.base_branch} from origin...", file=sys.stderr)
+        run(["git", "fetch", "origin", args.base_branch], cwd=str(repo_root))
+        base_sha = git_short_sha(repo_root, f"origin/{args.base_branch}")
+        print(f"[local-regression] Checking out origin/{args.base_branch} @ {base_sha} into worktree...", file=sys.stderr)
         run(
-            ["git", "worktree", "add", worktree_path, args.base_branch],
+            ["git", "worktree", "add", worktree_path, f"origin/{args.base_branch}"],
             cwd=str(repo_root),
         )
         print("[local-regression] Building base version...", file=sys.stderr)
@@ -107,7 +122,13 @@ def main() -> None:
         # Run regression script — output goes directly to stdout
         print("[local-regression] Running regression harness...\n", file=sys.stderr)
         subprocess.run(
-            [sys.executable, str(regression_script), "--base-dist", dist_base, "--pr-dist", dist_pr],
+            [
+                sys.executable, str(regression_script),
+                "--base-dist", dist_base,
+                "--pr-dist", dist_pr,
+                "--base-ref", f"{args.base_branch} @ {base_sha}",
+                "--pr-ref", f"{branch} @ {pr_sha}",
+            ],
             check=False,
         )
 

--- a/scripts/regression.py
+++ b/scripts/regression.py
@@ -9,6 +9,7 @@ Usage:
 import argparse
 import difflib
 import filecmp
+import json
 import os
 import pathlib
 import shutil
@@ -126,16 +127,76 @@ def run_astgen(dist_dir: str, input_dir: str, output_dir: str) -> tuple[bool, fl
         return False, elapsed
 
 
+def _normalize_json(path: pathlib.Path) -> list[str]:
+    """Parse a JSON file and re-serialize it with stable formatting for diffing."""
+    try:
+        obj = json.loads(path.read_text(errors="replace"))
+        return (json.dumps(obj, indent=2, sort_keys=True) + "\n").splitlines(keepends=True)
+    except Exception:
+        # Fall back to raw text if JSON is malformed
+        return path.read_text(errors="replace").splitlines(keepends=True)
+
+
+def _json_diff_summary(base_path: pathlib.Path, pr_path: pathlib.Path) -> str:
+    """
+    Return a one-line human-readable summary of what changed between two JSON files,
+    e.g. '3 keys added, 1 key removed, 7 values changed'.
+    Falls back to an empty string on parse error.
+    """
+    try:
+        base_obj = json.loads(base_path.read_text(errors="replace"))
+        pr_obj = json.loads(pr_path.read_text(errors="replace"))
+    except Exception:
+        return ""
+
+    added = removed = changed = 0
+
+    def _walk(b, p, depth: int = 0) -> None:
+        nonlocal added, removed, changed
+        if depth > 20:
+            return
+        if isinstance(b, dict) and isinstance(p, dict):
+            for k in set(b) | set(p):
+                if k not in b:
+                    added += 1
+                elif k not in p:
+                    removed += 1
+                else:
+                    _walk(b[k], p[k], depth + 1)
+        elif isinstance(b, list) and isinstance(p, list):
+            for i in range(min(len(b), len(p))):
+                _walk(b[i], p[i], depth + 1)
+            extra = len(p) - len(b)
+            if extra > 0:
+                added += extra
+            elif extra < 0:
+                removed += -extra
+        else:
+            if b != p:
+                changed += 1
+
+    _walk(base_obj, pr_obj)
+
+    parts = []
+    if added:
+        parts.append(f"{added} added")
+    if removed:
+        parts.append(f"{removed} removed")
+    if changed:
+        parts.append(f"{changed} changed")
+    return ", ".join(parts) if parts else "whitespace/ordering only"
+
+
 def compare_outputs(base_dir: pathlib.Path, pr_dir: pathlib.Path) -> dict:
     """
-    Compare two output directories byte-by-byte.
+    Compare two output directories.
 
     Returns:
         {
             "only_in_base": [relative_path, ...],
             "only_in_pr": [relative_path, ...],
-            "ast_diffs": [(rel_path, unified_diff_lines), ...],
-            "typemap_diffs": [(rel_path, unified_diff_lines), ...],
+            "ast_diffs": [(rel_path, diff_lines, summary), ...],
+            "typemap_diffs": [(rel_path, diff_lines, summary), ...],
         }
     """
     only_in_base = []
@@ -170,13 +231,10 @@ def compare_outputs(base_dir: pathlib.Path, pr_dir: pathlib.Path) -> dict:
         pp = pr_files[rel]
         if bp.stat().st_size == pp.stat().st_size and filecmp.cmp(str(bp), str(pp), shallow=False):
             continue
-        # Files differ — generate unified diff
-        try:
-            base_text = bp.read_text(errors="replace").splitlines(keepends=True)
-            pr_text = pp.read_text(errors="replace").splitlines(keepends=True)
-        except Exception:
-            base_text = []
-            pr_text = []
+
+        base_text = _normalize_json(bp)
+        pr_text = _normalize_json(pp)
+        summary = _json_diff_summary(bp, pp)
 
         diff_lines = list(
             difflib.unified_diff(
@@ -188,9 +246,9 @@ def compare_outputs(base_dir: pathlib.Path, pr_dir: pathlib.Path) -> dict:
         )
 
         if rel.endswith(".typemap"):
-            typemap_diffs.append((rel, diff_lines))
+            typemap_diffs.append((rel, diff_lines, summary))
         elif rel.endswith(".json"):
-            ast_diffs.append((rel, diff_lines))
+            ast_diffs.append((rel, diff_lines, summary))
 
     return {
         "only_in_base": only_in_base,
@@ -200,10 +258,38 @@ def compare_outputs(base_dir: pathlib.Path, pr_dir: pathlib.Path) -> dict:
     }
 
 
+def write_diff_files(diffs_dir: pathlib.Path, corpus_results: list) -> None:
+    """
+    Write full (untruncated) diff content to files in diffs_dir.
+
+    For each corpus that has diffs, creates:
+      <corpus-name>-ast.diff      — if AST diffs exist
+      <corpus-name>-typemap.diff  — if typemap diffs exist
+    """
+    diffs_dir.mkdir(parents=True, exist_ok=True)
+    for result in corpus_results:
+        name = result["name"]
+        cmp = result["comparison"]
+
+        for kind, key in (("ast", "ast_diffs"), ("typemap", "typemap_diffs")):
+            diffs = cmp[key]
+            if not diffs:
+                continue
+            parts = []
+            for rel, diff_lines, summary in diffs:
+                header = f"# {rel}"
+                if summary:
+                    header += f"  [{summary}]"
+                parts.append(header + "\n")
+                parts.append("".join(diff_lines))
+            (diffs_dir / f"{name}-{kind}.diff").write_text("".join(parts))
+
+
 def build_diff_details(diffs: list, kind: str, max_total_lines: int = 200) -> str:
     """
-    Render a collapsible <details> block with truncated unified diffs.
+    Render a collapsible <details> block with truncated normalized diffs.
     kind is 'AST' or 'typemap'.
+    Each entry in diffs is a (rel_path, diff_lines, summary) tuple.
     """
     n = len(diffs)
     if n == 0:
@@ -212,9 +298,15 @@ def build_diff_details(diffs: list, kind: str, max_total_lines: int = 200) -> st
     lines_used = 0
     diff_text_parts = []
 
-    for rel, diff_lines in diffs:
+    for rel, diff_lines, summary in diffs:
         if lines_used >= max_total_lines:
+            remaining = n - len(diff_text_parts)
+            diff_text_parts.append(f"\n... ({remaining} more files not shown)\n")
             break
+        header = f"# {rel}"
+        if summary:
+            header += f"  [{summary}]"
+        diff_text_parts.append(header + "\n")
         chunk = diff_lines[: max_total_lines - lines_used]
         lines_used += len(chunk)
         diff_text_parts.append("".join(chunk))
@@ -335,6 +427,24 @@ def main() -> None:
         metavar="N",
         help="PR number to display in the report header (e.g. 42).",
     )
+    parser.add_argument(
+        "--base-ref",
+        default=None,
+        metavar="REF",
+        help="Human-readable base ref label (e.g. 'main @ abc1234').",
+    )
+    parser.add_argument(
+        "--pr-ref",
+        default=None,
+        metavar="REF",
+        help="Human-readable PR ref label (e.g. 'my-branch @ def5678').",
+    )
+    parser.add_argument(
+        "--output-diffs",
+        default=None,
+        metavar="PATH",
+        help="Directory to write full (untruncated) diff files into.",
+    )
     args = parser.parse_args()
 
     base_dist = os.path.abspath(args.base_dist)
@@ -416,16 +526,28 @@ def main() -> None:
         shutil.rmtree(tmpdir, ignore_errors=True)
 
     # Build report
+    provenance = []
+    if args.base_ref:
+        provenance.append(f"**Base:** `{args.base_ref}`")
+    if args.pr_ref:
+        provenance.append(f"**PR:** `{args.pr_ref}`")
+
     report_parts = [
         "<!-- astgen-regression -->",
         "## astgen Regression Report",
         "",
     ]
+    if provenance:
+        report_parts.append(" | ".join(provenance))
+        report_parts.append("")
 
     for result in corpus_results:
         section = render_corpus_section(result["name"], result["label"], result, pr_label)
         report_parts.append(section)
         report_parts.append("")
+
+    if args.output_diffs:
+        write_diff_files(pathlib.Path(args.output_diffs), corpus_results)
 
     print("\n".join(report_parts))
 

--- a/src/Defaults.ts
+++ b/src/Defaults.ts
@@ -94,7 +94,8 @@ export const DEFAULT_TSC_OPTIONS: tsc.CompilerOptions = {
     removeComments: true
 }
 
-export const DEFAULT_TSC_TYPE_OPTIONS: number = tsc.TypeFormatFlags.NoTruncation | tsc.TypeFormatFlags.InTypeAlias
+export const MAX_TYPE_STRING_LENGTH: number = 500
+export const DEFAULT_TSC_TYPE_OPTIONS: number = tsc.TypeFormatFlags.InTypeAlias
 
 export const ANY: string = "any"
 export const UNKNOWN: string = "unknown"

--- a/src/TscUtils.ts
+++ b/src/TscUtils.ts
@@ -37,7 +37,7 @@ export default class TscUtils {
      */
     typeMapForFile(file: string): TypeMap {
         let addType: (node: tsc.Node) => void = (node: tsc.Node): void => {
-            if (tsc.isSourceFile(node)) return
+            if (!this.shouldResolveType(node)) return
             let typeStr
             if (this.isSignatureDeclaration(node)) {
                 const signature: tsc.Signature = this.typeChecker.getSignatureFromDeclaration(node)!
@@ -78,6 +78,7 @@ export default class TscUtils {
         try {
             const tpe: string = this.typeChecker.typeToString(node, undefined, Defaults.DEFAULT_TSC_TYPE_OPTIONS)
             if (tpe.length === 0) return Defaults.ANY
+            if (tpe.length > Defaults.MAX_TYPE_STRING_LENGTH) return Defaults.ANY
             if (tpe == Defaults.UNKNOWN) return Defaults.ANY
             if (tpe.startsWith(Defaults.UNRESOLVED)) return Defaults.ANY
             if (Defaults.STRING_REGEX.test(tpe)) return "string"
@@ -92,6 +93,18 @@ export default class TscUtils {
         return tsc.isSetAccessor(node) || tsc.isGetAccessor(node) ||
             tsc.isConstructSignatureDeclaration(node) || tsc.isMethodDeclaration(node) ||
             tsc.isFunctionDeclaration(node) || tsc.isConstructorDeclaration(node)
+    }
+
+    private shouldResolveType(node: tsc.Node): boolean {
+        const k = node.kind
+        if (k === tsc.SyntaxKind.SourceFile) return false
+        if (k === tsc.SyntaxKind.EndOfFileToken) return false
+        if (k === tsc.SyntaxKind.SyntaxList) return false
+        if (k >= tsc.SyntaxKind.FirstKeyword && k <= tsc.SyntaxKind.LastKeyword) return false
+        if (k >= tsc.SyntaxKind.FirstPunctuation && k <= tsc.SyntaxKind.LastPunctuation) return false
+        if (k === tsc.SyntaxKind.Decorator) return false
+        if (k >= tsc.SyntaxKind.FirstStatement && k <= tsc.SyntaxKind.LastStatement) return false
+        return true
     }
 
 }

--- a/test/astgen.test.ts
+++ b/test/astgen.test.ts
@@ -193,4 +193,25 @@ describe('astgen basic functionality', () => {
         })
     })
 
+    it('should produce bounded-length type strings for complex union types', async () => {
+        // Validates that the pipeline produces short type strings for complex types.
+        // TypeScript's own truncation (~160 chars) handles this; the 500-char guard in
+        // safeTypeToString is a defense-in-depth layer for future TS version changes.
+        const code = `
+type Long = "a1"|"a2"|"a3"|"a4"|"a5"|"a6"|"a7"|"a8"|"a9"|"a10"|
+            "b1"|"b2"|"b3"|"b4"|"b5"|"b6"|"b7"|"b8"|"b9"|"b10"|
+            "c1"|"c2"|"c3"|"c4"|"c5"|"c6"|"c7"|"c8"|"c9"|"c10"|
+            "d1"|"d2"|"d3"|"d4"|"d5"|"d6"|"d7"|"d8"|"d9"|"d10"|
+            "e1"|"e2"|"e3"|"e4"|"e5"|"e6"|"e7"|"e8"|"e9"|"e10"|
+            "f1"|"f2"|"f3"|"f4"|"f5"|"f6"|"f7"|"f8"|"f9"|"f10";
+const x: Long = "a1";
+`
+        await setupTestFixture(code, "main.ts", {tsTypes: true}, (tmpDir: string) => {
+            const resultTypes = fs.readFileSync(path.join(tmpDir, "ast_out", "main.ts.typemap")).toString()
+            const parsed = JSON.parse(resultTypes)
+            const values = Object.values(parsed) as string[]
+            expect(values.every(v => (v as string).length <= 500)).toBe(true)
+        })
+    })
+
 })


### PR DESCRIPTION
- Remove TypeFormatFlags.NoTruncation (primary OOM cause); keep InTypeAlias for structural type expansion. Add MAX_TYPE_STRING_LENGTH (500) as a defense-in-depth guard in safeTypeToString.
- Skip keyword and punctuation AST nodes before calling
  getTypeAtLocation via new shouldResolveType() guard, eliminating expensive no-op calls on trivial syntax nodes.
- Extend shouldResolveType to skip decorator and statement nodes

Also for regression testing:
- Always fetch origin/{base} before creating the worktree so the
  comparison is against the authoritative remote, not a stale local ref
- Use origin/{base_branch} as the worktree ref in the local runner
- Show commit SHAs (branch @ short-sha) in local output and CI report so it is immediately visible which exact commits are being compared
- Pass --base-ref / --pr-ref through to regression.py; rendered as a provenance line at the top of the Markdown report
- Add explicit git fetch origin {base_ref} step in the CI workflow
  before the worktree creation for the same reason
- _normalize_json - Before diffing, parses the JSON and re-serializes with indent=2, sort_keys=True. This eliminates false diffs from key ordering instability or compact vs. pretty-printed output. A file that  only changed whitespace/key order now shows as identical.
- _json_diff_summary - Walks both parsed JSON trees and counts added / removed / changed nodes. Each diff entry in the report now shows a one-liner like [42 changed, 3 added] at the top, giving instant signal about the scope of the change without reading the raw diff.
- build_diff_details - Updated to use the new (rel, diff_lines, summary) tuple and prints the per-file summary as a comment header line before each diff chunk. Also fixed the "N more files not shown" truncation count (was wrong before).
- Upload and link full diffs.