### PR TITLE
Reduce memory pressure and redundant I/O for large projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joernio/astgen",
-  "version": "3.39.0",
+  "version": "3.40.0",
   "description": "Generate JS/TS AST in json format with Babel",
   "exports": "./index.js",
   "keywords": [

--- a/src/AstGenerator.ts
+++ b/src/AstGenerator.ts
@@ -196,7 +196,7 @@ function writeAstFile(file: string, ast: babelParser.ParseResult, options: Optio
         ast: ast,
     }
     fs.mkdirSync(path.dirname(outAstFile), {recursive: true})
-    fs.writeFileSync(outAstFile, JsonUtils.stringifyCircular(data))
+    JsonUtils.writeJsonStreamCircular(outAstFile, data)
     console.log("Converted AST for", relativePath, "to", outAstFile)
 }
 
@@ -214,7 +214,7 @@ function writeTypesFile(file: string, seenTypes: TypeMap, options: Options): voi
     const relativePath: string = path.relative(options.src, file)
     const outTypeFile: string = path.join(options.output, relativePath + ".typemap")
     fs.mkdirSync(path.dirname(outTypeFile), {recursive: true})
-    fs.writeFileSync(outTypeFile, JsonUtils.stringify(Object.fromEntries(seenTypes)))
+    JsonUtils.writeMapToJsonFile(outTypeFile, seenTypes)
     console.log("Converted types for", relativePath, "to", outTypeFile)
 }
 

--- a/src/Defaults.ts
+++ b/src/Defaults.ts
@@ -87,8 +87,6 @@ export const DEFAULT_TSC_OPTIONS: tsc.CompilerOptions = {
     allowUnreachableCode: true,
     allowUnusedLabels: true,
     alwaysStrict: false,
-    ignoreDeprecations: "5.0",
-    noStrictGenericChecks: true,
     noUncheckedIndexedAccess: false,
     noPropertyAccessFromIndexSignature: false,
     removeComments: true

--- a/src/FileUtils.ts
+++ b/src/FileUtils.ts
@@ -1,7 +1,7 @@
 import Options from "./Options"
 import * as Defaults from "./Defaults"
 
-import {readdirpPromise} from 'readdirp'
+import {readdirp} from 'readdirp'
 import * as fs from "node:fs"
 import nReadlines from "n-readlines"
 import * as path from "node:path"
@@ -32,14 +32,6 @@ function ignoreDirectory(options: Options, dirName: string, fullPath: string): b
         Defaults.IGNORE_DIRS.includes(dirName.toLowerCase())
 }
 
-function isEmscripten(fileWithDir: string): boolean {
-    if (fs.readFileSync(fileWithDir, "utf-8").toString().includes("// EMSCRIPTEN_START_ASM")) {
-        console.warn("Parsing", fileWithDir, ":", "File skipped as it contains EMSCRIPTEN code")
-        return true
-    }
-    return false
-}
-
 function isTooBig(fileWithDir: string): boolean {
     if (fs.statSync(fileWithDir).size > Defaults.MAX_FILE_SIZE_BYTES) {
         console.warn(fileWithDir, "exceeds maximum file size of", Defaults.MAX_FILE_SIZE_BYTES, "bytes")
@@ -48,7 +40,9 @@ function isTooBig(fileWithDir: string): boolean {
     return false
 }
 
-function isTooLargeOrHasLongLines(fileWithDir: string): boolean {
+const EMSCRIPTEN_MARKER = Buffer.from("// EMSCRIPTEN_START_ASM")
+
+function shouldSkipFileContent(fileWithDir: string): boolean {
     const lines = new nReadlines(fileWithDir)
     let lineNumber = 0
     let line: Buffer | false
@@ -62,25 +56,34 @@ function isTooLargeOrHasLongLines(fileWithDir: string): boolean {
             console.warn(fileWithDir, "more than", Defaults.MAX_LOC_IN_FILE, "lines of code")
             return true
         }
+        if (line.includes(EMSCRIPTEN_MARKER)) {
+            console.warn("Parsing", fileWithDir, ":", "File skipped as it contains EMSCRIPTEN code")
+            return true
+        }
     }
     return false
 }
 
-function ignoreFile(options: Options, fileName: string, fullPath: string, extensions: string[]): boolean {
+function ignoreFileByName(options: Options, fileName: string, fullPath: string, extensions: string[]): boolean {
     return !extensions.some((e: string) => fileName.endsWith(e)) ||
         fileName.startsWith(".") ||
         fileName.startsWith("__") ||
         Defaults.IGNORE_FILE_PATTERN.test(fileName) ||
         options["exclude-file"].some((e: string) => fileIsInIgnorePath(options, fullPath, e)) ||
-        options["exclude-regex"]?.test(fullPath) ||
-        isTooBig(fullPath) ||
-        isTooLargeOrHasLongLines(fullPath) ||
-        isEmscripten(fullPath)
+        (options["exclude-regex"]?.test(fullPath) ?? false)
+}
+
+function shouldSkipFileIO(fullPath: string): boolean {
+    return isTooBig(fullPath) || shouldSkipFileContent(fullPath)
 }
 
 /**
  * Asynchronously retrieves all files with the specified extensions from the source directory,
  * applying exclusion rules defined in the provided options.
+ *
+ * Uses the streaming readdirp API so that entry objects can be GC'd incrementally.
+ * Cheap name-based filters run during traversal; expensive I/O checks (file size,
+ * line scanning) run per-entry as entries stream in.
  *
  * @param options - The options object containing source directory and exclusion patterns.
  * @param extensions - An array of file extensions to include (e.g., ['.js', '.ts']).
@@ -88,13 +91,18 @@ function ignoreFile(options: Options, fileName: string, fullPath: string, extens
  */
 export async function filesWithExtensions(options: Options, extensions: string[]): Promise<string[]> {
     const dir = options.src
-    const files = await readdirpPromise(dir, {
-        fileFilter: (f) => !ignoreFile(options, f.basename, f.fullPath, extensions),
+    const stream = readdirp(dir, {
+        fileFilter: (f) => !ignoreFileByName(options, f.basename, f.fullPath, extensions),
         directoryFilter: (d) => !ignoreDirectory(options, d.basename, d.fullPath),
         lstat: true
     })
-    // @ts-ignore
-    return files.map(file => file.fullPath)
+    const files: string[] = []
+    for await (const entry of stream) {
+        if (!shouldSkipFileIO(entry.fullPath)) {
+            files.push(entry.fullPath)
+        }
+    }
+    return files
 }
 
 /**

--- a/src/JsonUtils.ts
+++ b/src/JsonUtils.ts
@@ -1,37 +1,146 @@
+import * as fs from "node:fs"
+
+const STREAM_BUFFER_SIZE = 64 * 1024
+
 /**
- * Returns a replacer function for JSON.stringify that handles cyclic references.
- * Objects that have already been seen are omitted to prevent circular structure errors.
- * @returns {(key: any, value: any) => any} A replacer function for JSON.stringify.
+ * Writes a Map<string, string> as a JSON object directly to a file using buffered I/O,
+ * avoiding both the intermediate plain object from Object.fromEntries and the full JSON string.
+ *
+ * @param filePath The file path to write to.
+ * @param map The map to serialize.
  */
-const getCircularReplacer = () => {
-    const seen = new WeakSet()
-    return (_: any, value: any): any => {
-        if (typeof value === "object" && value !== null) {
-            if (seen.has(value)) {
-                return
-            }
-            seen.add(value)
+export function writeMapToJsonFile(filePath: string, map: Map<string, string>): void {
+    const fd = fs.openSync(filePath, "w")
+    let buffer = ""
+
+    function flush(): void {
+        if (buffer.length > 0) {
+            fs.writeSync(fd, buffer)
+            buffer = ""
         }
-        return value
+    }
+
+    function write(s: string): void {
+        buffer += s
+        if (buffer.length >= STREAM_BUFFER_SIZE) {
+            flush()
+        }
+    }
+
+    try {
+        write("{")
+        let first = true
+        for (const [key, value] of map) {
+            if (!first) write(",")
+            first = false
+            write(JSON.stringify(key))
+            write(":")
+            write(JSON.stringify(value))
+        }
+        write("}")
+        flush()
+    } finally {
+        fs.closeSync(fd)
     }
 }
 
 /**
- * Safely serializes objects with potential circular references to a JSON string.
- * Uses a custom replacer to omit cyclic structures, preventing errors from JSON.stringify.
- * @param data The value to convert to a JSON string.
- * @returns A JSON string representation of the input, with cycles omitted.
+ * Writes a value as JSON directly to a file using buffered streaming,
+ * handling circular references without materializing the full JSON string in memory.
+ * Semantics match JSON.stringify with getCircularReplacer:
+ * - Circular/duplicate object references are omitted (skipped in objects, null in arrays)
+ * - undefined, functions, and symbols are omitted in objects and become null in arrays
+ *
+ * @param filePath The file path to write to.
+ * @param data The value to serialize.
  */
-export function stringifyCircular(data: any): string {
-    return JSON.stringify(data, getCircularReplacer())
-}
+export function writeJsonStreamCircular(filePath: string, data: any): void {
+    const fd = fs.openSync(filePath, "w")
+    let buffer = ""
+    const seen = new WeakSet<object>()
 
-/**
- * Serializes a JavaScript value to a JSON string.
- * Unlike stringifyCircular, this function does not handle circular references and will throw an TypeError if any are present.
- * @param data The value to convert to a JSON string.
- * @returns A JSON string representation of the input.
- */
-export function stringify(data: any): string {
-    return JSON.stringify(data)
+    function flush(): void {
+        if (buffer.length > 0) {
+            fs.writeSync(fd, buffer)
+            buffer = ""
+        }
+    }
+
+    function write(s: string): void {
+        buffer += s
+        if (buffer.length >= STREAM_BUFFER_SIZE) {
+            flush()
+        }
+    }
+
+    function shouldSkip(v: any): boolean {
+        if (v === undefined || typeof v === "function" || typeof v === "symbol") return true
+        if (typeof v === "object" && v !== null && seen.has(v)) return true
+        return false
+    }
+
+    function writeValue(value: any): void {
+        if (value === null) { write("null"); return }
+        switch (typeof value) {
+            case "string":
+                write(JSON.stringify(value))
+                return
+            case "number":
+                write(isFinite(value) ? String(value) : "null")
+                return
+            case "boolean":
+                write(value ? "true" : "false")
+                return
+            case "object":
+                seen.add(value)
+                if (typeof value.toJSON === "function") {
+                    writeValue(value.toJSON())
+                    return
+                }
+                if (Array.isArray(value)) {
+                    writeArray(value)
+                } else {
+                    writeObject(value)
+                }
+                return
+            default:
+                write("null")
+                return
+        }
+    }
+
+    function writeArray(arr: any[]): void {
+        write("[")
+        for (let i = 0; i < arr.length; i++) {
+            if (i > 0) write(",")
+            if (shouldSkip(arr[i])) {
+                write("null")
+            } else {
+                writeValue(arr[i])
+            }
+        }
+        write("]")
+    }
+
+    function writeObject(obj: object): void {
+        write("{")
+        let first = true
+        for (const key of Object.keys(obj)) {
+            const v = (obj as any)[key]
+            if (shouldSkip(v)) continue
+            if (!first) write(",")
+            first = false
+            write(JSON.stringify(key))
+            write(":")
+            writeValue(v)
+        }
+        write("}")
+    }
+
+    try {
+        writeValue(data)
+        flush()
+    } finally {
+        fs.closeSync(fd)
+    }
 }


### PR DESCRIPTION
- Merge isTooLargeOrHasLongLines and isEmscripten into a single shouldSkipFileContent pass, eliminating a redundant full-file read per candidate file. Pre-allocate the emscripten marker as a Buffer constant to avoid repeated string-to-Buffer conversion in the scan loop.

- Split ignoreFile into cheap name-based filtering (ignoreFileByName, used during directory traversal) and expensive I/O checks (shouldSkipFileIO, applied per-entry). Switch from readdirpPromise to streaming readdirp so entry objects can be GC'd incrementally instead of materializing the full file list.

- Replace JSON.stringify-based AST serialization with a buffered streaming writer (writeJsonStreamCircular) that writes directly to a file descriptor in 64 KB chunks, avoiding the full JSON string in memory. Handles circular references, toJSON(), and matches JSON.stringify semantics.

- Replace stringify(Object.fromEntries(typeMap)) with writeMapToJsonFile that iterates Map entries directly to a buffered file descriptor, skipping the intermediate plain object copy and full JSON string.