### PR TITLE
Performance and maintenance improvements

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -27,7 +27,6 @@ jobs:
         run: |
           yarn install
           yarn build
-          cp -r dist dist-pr
 
       - name: Build base version
         run: |
@@ -35,21 +34,23 @@ jobs:
           git fetch origin ${{ github.base_ref }}
           git worktree add ../astgen-base "origin/${{ github.base_ref }}"
           (cd ../astgen-base && yarn install && yarn build)
-          cp -r ../astgen-base/dist dist-base
-          git worktree remove --force ../astgen-base
 
       - name: Run regression script
         run: |
           BASE_SHA=$(git rev-parse --short "origin/${{ github.base_ref }}")
           PR_SHA=$(git rev-parse --short HEAD)
           python3 scripts/regression.py \
-            --base-dist dist-base \
-            --pr-dist dist-pr \
+            --base-dist ../astgen-base/dist \
+            --pr-dist dist \
             --pr-number "${{ github.event.pull_request.number }}" \
             --base-ref "${{ github.base_ref }} @ ${BASE_SHA}" \
             --pr-ref "${{ github.head_ref }} @ ${PR_SHA}" \
             --output-diffs regression-diffs \
             > regression-report.md
+
+      - name: Clean up base worktree
+        if: always()
+        run: git worktree remove --force ../astgen-base
 
       - name: Upload diff artifacts
         uses: actions/upload-artifact@v6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joernio/astgen",
-  "version": "3.40.0",
+  "version": "3.41.0",
   "description": "Generate JS/TS AST in json format with Babel",
   "exports": "./index.js",
   "keywords": [
@@ -15,8 +15,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@babel/parser": "^7.27.3",
-    "effect": "^3.19.14",
-    "n-readlines": "^1.0.1",
+    "effect": "^3.21.0",
     "readdirp": "^4.1.2",
     "typescript": "^5.9.3",
     "yargs": "^17.7.2"
@@ -39,7 +38,6 @@
   "devDependencies": {
     "@tsconfig/node18": "^18.2.4",
     "@types/jest": "^30.0.0",
-    "@types/n-readlines": "^1.0.6",
     "@types/node": "^18.11.9",
     "@types/yargs": "^17.0.33",
     "@yao-pkg/pkg": "^6.12.0",

--- a/scripts/regression-local.py
+++ b/scripts/regression-local.py
@@ -15,7 +15,6 @@ Or via yarn:
 import argparse
 import os
 import pathlib
-import shutil
 import subprocess
 import sys
 
@@ -85,20 +84,15 @@ def main() -> None:
     print(f"[local-regression] Current branch: {branch} @ {pr_sha}", file=sys.stderr)
     print(f"[local-regression] Base branch:    {args.base_branch}", file=sys.stderr)
 
-    # Keep dist-pr and dist-base inside the repo root so that Node can resolve
-    # node_modules by walking up the directory tree (same as the CI workflow).
     worktree_path = str(repo_root / ".worktrees" / "regression-base")
-    dist_pr = str(repo_root / "dist-pr")
-    dist_base = str(repo_root / "dist-base")
+    dist_pr = str(repo_root / "dist")
+    dist_base = os.path.join(worktree_path, "dist")
 
     try:
         # Build PR version (current working tree)
         print("[local-regression] Building PR version (current tree)...", file=sys.stderr)
         run(["yarn", "install"], cwd=str(repo_root))
         run(["yarn", "build"], cwd=str(repo_root))
-        if os.path.exists(dist_pr):
-            shutil.rmtree(dist_pr)
-        shutil.copytree(str(repo_root / "dist"), dist_pr)
 
         # Build base version via git worktree
         print(f"[local-regression] Fetching {args.base_branch} from origin...", file=sys.stderr)
@@ -112,14 +106,11 @@ def main() -> None:
         print("[local-regression] Building base version...", file=sys.stderr)
         run(["yarn", "install"], cwd=worktree_path)
         run(["yarn", "build"], cwd=worktree_path)
-        if os.path.exists(dist_base):
-            shutil.rmtree(dist_base)
-        shutil.copytree(os.path.join(worktree_path, "dist"), dist_base)
 
-        # Remove worktree before running regression
-        run(["git", "worktree", "remove", worktree_path], cwd=str(repo_root))
-
-        # Run regression script — output goes directly to stdout
+        # Run regression script with each binary served from its own build directory
+        # so that Node resolves node_modules relative to each binary's location,
+        # not from the shared repo root. This matters when dependencies change between
+        # base and PR.
         print("[local-regression] Running regression harness...\n", file=sys.stderr)
         subprocess.run(
             [
@@ -133,9 +124,7 @@ def main() -> None:
         )
 
     finally:
-        shutil.rmtree(dist_pr, ignore_errors=True)
-        shutil.rmtree(dist_base, ignore_errors=True)
-        # Clean up worktree registration if it still exists (e.g. on early failure)
+        # Clean up worktree registration (also removes worktree_path/node_modules)
         subprocess.run(
             ["git", "worktree", "remove", "--force", worktree_path],
             cwd=str(repo_root),

--- a/src/AstGenerator.ts
+++ b/src/AstGenerator.ts
@@ -1,6 +1,7 @@
 import Options from "./Options"
 import * as Defaults from "./Defaults"
 import * as FileUtils from "./FileUtils"
+import type { FileEntry } from "./FileUtils"
 import * as JsonUtils from "./JsonUtils"
 import * as VueCodeCleaner from "./VueCodeCleaner"
 import TscUtils, {TypeMap} from "./TscUtils"
@@ -48,20 +49,6 @@ function VoidWithTry(errMessage: string, arg: string, f: () => void): void {
 }
 
 /**
- * Converts a single JavaScript or TypeScript file to an Abstract Syntax Tree (AST).
- * Reads the file content from the filesystem and passes it to the codeToJsAst function
- * for parsing with Babel.
- *
- * @param file - The absolute or relative path to the JS/TS file to be parsed
- * @returns A Babel ParseResult object representing the AST of the file's content
- * @throws Will throw an error if the file cannot be read or if parsing fails
- * @see codeToJsAst - The underlying function used for parsing code strings
- */
-function fileToJsAst(file: string): babelParser.ParseResult {
-    return codeToJsAst(fs.readFileSync(file, "utf-8"))
-}
-
-/**
  * Converts a JavaScript or TypeScript code string to an Abstract Syntax Tree (AST).
  *
  * The function first attempts to parse the code with standard Babel parser options.
@@ -83,22 +70,19 @@ function codeToJsAst(code: string): babelParser.ParseResult {
 }
 
 /**
- * Converts a single Vue file to an Abstract Syntax Tree (AST).
+ * Converts pre-read Vue file content to an Abstract Syntax Tree (AST).
  *
- * This function reads the Vue file content from the filesystem, cleans the code
- * using the VueCodeCleaner utility to extract and process the script section,
- * and then parses the cleaned code into an AST using the Babel parser.
+ * This function cleans the code using the VueCodeCleaner utility to extract and
+ * process the script section, then parses the cleaned code into an AST using Babel.
  *
- * @param file - The absolute or relative path to the Vue file to be parsed
+ * @param content - The raw content of the Vue file
  * @returns A Babel ParseResult object representing the AST of the Vue file's script content
- * @throws Will throw an error if the file cannot be read or if parsing fails
+ * @throws Will throw an error if parsing fails
  * @see VueCodeCleaner.cleanVueCode - The utility used to extract script content from Vue files
  * @see codeToJsAst - The underlying function used for parsing the extracted code
  */
-function toVueAst(file: string): babelParser.ParseResult {
-    const code = fs.readFileSync(file, "utf-8")
-    const cleanedCode = VueCodeCleaner.cleanVueCode(code)
-    return codeToJsAst(cleanedCode)
+function toVueAst(content: string): babelParser.ParseResult {
+    return codeToJsAst(VueCodeCleaner.cleanVueCode(content))
 }
 
 /**
@@ -136,19 +120,20 @@ function buildTscUtils(files: string[], options: Options): O.Option<TscUtils> {
  */
 async function createJSAst(options: Options): Promise<void> {
     try {
-        const srcFiles: string[] = await FileUtils.filesWithExtensions(options, Defaults.JS_EXTENSIONS)
-        const tscUtils: O.Option<TscUtils> = buildTscUtils(srcFiles, options)
+        const srcFiles: FileEntry[] = await FileUtils.filesWithExtensions(options, Defaults.JS_EXTENSIONS)
+        const tscUtils: O.Option<TscUtils> = buildTscUtils(srcFiles.map(f => f.path), options)
+        const createdDirs = new Set<string>()
         for (const file of srcFiles) {
-            VoidWithTry("Parsing", file, () => {
-                const ast: babelParser.ParseResult = fileToJsAst(file)
-                writeAstFile(file, ast, options)
-                VoidWithTry("Retrieving types", file, () => {
+            VoidWithTry("Parsing", file.path, () => {
+                const ast: babelParser.ParseResult = codeToJsAst(file.content)
+                writeAstFile(file.path, ast, options, createdDirs)
+                VoidWithTry("Retrieving types", file.path, () => {
                     pipe(
                         tscUtils,
-                        O.map(t => t.typeMapForFile(file)),
+                        O.map(t => t.typeMapForFile(file.path)),
                         O.filter(m => m.size !== 0),
                         O.toArray
-                    ).forEach(m => writeTypesFile(file, m, options))
+                    ).forEach(m => writeTypesFile(file.path, m, options, createdDirs))
                 })
             })
         }
@@ -168,10 +153,11 @@ async function createJSAst(options: Options): Promise<void> {
  * @returns A Promise that resolves when all Vue files have been processed.
  */
 async function createVueAst(options: Options): Promise<void> {
-    const srcFiles: string[] = await FileUtils.filesWithExtensions(options, [".vue"])
+    const srcFiles: FileEntry[] = await FileUtils.filesWithExtensions(options, [".vue"])
+    const createdDirs = new Set<string>()
     for (const file of srcFiles) {
-        VoidWithTry("", file, () => {
-            writeAstFile(file, toVueAst(file), options)
+        VoidWithTry("", file.path, () => {
+            writeAstFile(file.path, toVueAst(file.content), options, createdDirs)
         })
     }
 }
@@ -182,12 +168,14 @@ async function createVueAst(options: Options): Promise<void> {
  * The output file is created in the output directory specified in the options,
  * preserving the relative path structure from the source directory. The AST data
  * is serialized using a utility that handles circular references.
+ * Output directories are created at most once per unique path via `createdDirs`.
  *
  * @param file - The absolute path to the source file.
  * @param ast - The Babel ParseResult object representing the AST of the file.
  * @param options - Configuration options containing source and output directories.
+ * @param createdDirs - Set tracking already-created output directories to avoid redundant mkdirSync calls.
  */
-function writeAstFile(file: string, ast: babelParser.ParseResult, options: Options): void {
+function writeAstFile(file: string, ast: babelParser.ParseResult, options: Options, createdDirs: Set<string>): void {
     const relativePath: string = path.relative(options.src, file)
     const outAstFile: string = path.join(options.output, relativePath + ".json")
     const data = {
@@ -195,7 +183,11 @@ function writeAstFile(file: string, ast: babelParser.ParseResult, options: Optio
         relativeName: relativePath,
         ast: ast,
     }
-    fs.mkdirSync(path.dirname(outAstFile), {recursive: true})
+    const dir = path.dirname(outAstFile)
+    if (!createdDirs.has(dir)) {
+        fs.mkdirSync(dir, {recursive: true})
+        createdDirs.add(dir)
+    }
     JsonUtils.writeJsonStreamCircular(outAstFile, data)
     console.log("Converted AST for", relativePath, "to", outAstFile)
 }
@@ -205,15 +197,21 @@ function writeAstFile(file: string, ast: babelParser.ParseResult, options: Optio
  *
  * The function serializes the provided `TypeMap` and writes it to a `.typemap` file
  * in the output directory, preserving the relative path structure from the source directory.
+ * Output directories are created at most once per unique path via `createdDirs`.
  *
  * @param file - The absolute path to the source file.
  * @param seenTypes - The `TypeMap` containing type information to be written.
  * @param options - Configuration options containing source and output directories.
+ * @param createdDirs - Set tracking already-created output directories to avoid redundant mkdirSync calls.
  */
-function writeTypesFile(file: string, seenTypes: TypeMap, options: Options): void {
+function writeTypesFile(file: string, seenTypes: TypeMap, options: Options, createdDirs: Set<string>): void {
     const relativePath: string = path.relative(options.src, file)
     const outTypeFile: string = path.join(options.output, relativePath + ".typemap")
-    fs.mkdirSync(path.dirname(outTypeFile), {recursive: true})
+    const dir = path.dirname(outTypeFile)
+    if (!createdDirs.has(dir)) {
+        fs.mkdirSync(dir, {recursive: true})
+        createdDirs.add(dir)
+    }
     JsonUtils.writeMapToJsonFile(outTypeFile, seenTypes)
     console.log("Converted types for", relativePath, "to", outTypeFile)
 }
@@ -222,22 +220,21 @@ function writeTypesFile(file: string, seenTypes: TypeMap, options: Options): voi
  * Determines the project type in the given source directory and triggers AST generation accordingly.
  *
  * This function checks if the provided source directory contains a `package.json` or `rush.json` file
- * to identify it as a Node.js or JavaScript/TypeScript project. If so, it calls `createJSAst` to generate
- * ASTs for the source files. If neither file is found, it logs an error and exits the process.
+ * to identify it as a Node.js or JavaScript/TypeScript project. If neither marker is found, it logs
+ * a warning and falls back to JS/TS processing rather than exiting.
  *
  * @param options - Configuration options containing the source directory and output settings.
- * @returns A Promise that resolves when AST generation is complete or the process exits on error.
+ * @returns A Promise that resolves when AST generation is complete.
  */
 async function createXAst(options: Options): Promise<void> {
     const srcDir: string = options.src
-    if (
+    const isKnownJsProject =
         FileUtils.fileExistsAndIsReadable(path.join(srcDir, "package.json")) ||
         FileUtils.fileExistsAndIsReadable(path.join(srcDir, "rush.json"))
-    ) {
-        return await createJSAst(options)
+    if (!isKnownJsProject) {
+        console.warn("No package.json or rush.json found in", srcDir, "— processing as JS/TS project")
     }
-    console.error("Unknown project type:", srcDir)
-    process.exit(1)
+    return await createJSAst(options)
 }
 
 /**

--- a/src/FileUtils.ts
+++ b/src/FileUtils.ts
@@ -3,8 +3,9 @@ import * as Defaults from "./Defaults"
 
 import {readdirp} from 'readdirp'
 import * as fs from "node:fs"
-import nReadlines from "n-readlines"
 import * as path from "node:path"
+
+export type FileEntry = { path: string; content: string }
 
 function dirIsInIgnorePath(options: Options, fullPath: string, ignorePath: string): boolean {
     if (path.isAbsolute(ignorePath)) {
@@ -32,38 +33,6 @@ function ignoreDirectory(options: Options, dirName: string, fullPath: string): b
         Defaults.IGNORE_DIRS.includes(dirName.toLowerCase())
 }
 
-function isTooBig(fileWithDir: string): boolean {
-    if (fs.statSync(fileWithDir).size > Defaults.MAX_FILE_SIZE_BYTES) {
-        console.warn(fileWithDir, "exceeds maximum file size of", Defaults.MAX_FILE_SIZE_BYTES, "bytes")
-        return true
-    }
-    return false
-}
-
-const EMSCRIPTEN_MARKER = Buffer.from("// EMSCRIPTEN_START_ASM")
-
-function shouldSkipFileContent(fileWithDir: string): boolean {
-    const lines = new nReadlines(fileWithDir)
-    let lineNumber = 0
-    let line: Buffer | false
-    while ((line = lines.next()) !== false) {
-        lineNumber++
-        if (line.length > Defaults.MAX_LINE_LENGTH) {
-            console.warn(fileWithDir, "line", lineNumber, "exceeds", Defaults.MAX_LINE_LENGTH, "bytes")
-            return true
-        }
-        if (lineNumber > Defaults.MAX_LOC_IN_FILE) {
-            console.warn(fileWithDir, "more than", Defaults.MAX_LOC_IN_FILE, "lines of code")
-            return true
-        }
-        if (line.includes(EMSCRIPTEN_MARKER)) {
-            console.warn("Parsing", fileWithDir, ":", "File skipped as it contains EMSCRIPTEN code")
-            return true
-        }
-    }
-    return false
-}
-
 function ignoreFileByName(options: Options, fileName: string, fullPath: string, extensions: string[]): boolean {
     return !extensions.some((e: string) => fileName.endsWith(e)) ||
         fileName.startsWith(".") ||
@@ -73,8 +42,36 @@ function ignoreFileByName(options: Options, fileName: string, fullPath: string, 
         (options["exclude-regex"]?.test(fullPath) ?? false)
 }
 
-function shouldSkipFileIO(fullPath: string): boolean {
-    return isTooBig(fullPath) || shouldSkipFileContent(fullPath)
+// Reads the file content if it passes all size/content guards, or returns null with a warning.
+// Uses the stats object already populated by readdirp (lstat: true) to avoid a redundant stat call.
+// Files that pass the size check are read once here; the content is returned to avoid a second
+// read during parsing.
+function readFileIfValid(fileWithDir: string, stats: fs.Stats): string | null {
+    if (stats.size > Defaults.MAX_FILE_SIZE_BYTES) {
+        console.warn(fileWithDir, "exceeds maximum file size of", Defaults.MAX_FILE_SIZE_BYTES, "bytes")
+        return null
+    }
+    const content = fs.readFileSync(fileWithDir, "utf-8")
+    if (content.includes("// EMSCRIPTEN_START_ASM")) {
+        console.warn("Parsing", fileWithDir, ":", "File skipped as it contains EMSCRIPTEN code")
+        return null
+    }
+    let lineStart = 0
+    let lineCount = 0
+    for (let i = 0; i <= content.length; i++) {
+        if (i === content.length || content[i] === "\n") {
+            if (i - lineStart > Defaults.MAX_LINE_LENGTH) {
+                console.warn(fileWithDir, "line", lineCount + 1, "exceeds", Defaults.MAX_LINE_LENGTH, "bytes")
+                return null
+            }
+            if (++lineCount >= Defaults.MAX_LOC_IN_FILE) {
+                console.warn(fileWithDir, "more than", Defaults.MAX_LOC_IN_FILE, "lines of code")
+                return null
+            }
+            lineStart = i + 1
+        }
+    }
+    return content
 }
 
 /**
@@ -83,23 +80,28 @@ function shouldSkipFileIO(fullPath: string): boolean {
  *
  * Uses the streaming readdirp API so that entry objects can be GC'd incrementally.
  * Cheap name-based filters run during traversal; expensive I/O checks (file size,
- * line scanning) run per-entry as entries stream in.
+ * line scanning) run per-entry as entries stream in. The file content is read once and
+ * returned with each entry to avoid a second read during parsing.
+ * When `options.recurse` is false, only files in the top-level source directory are returned.
  *
  * @param options - The options object containing source directory and exclusion patterns.
  * @param extensions - An array of file extensions to include (e.g., ['.js', '.ts']).
- * @returns A promise that resolves to an array of absolute file paths matching the extensions and not excluded.
+ * @returns A promise that resolves to an array of FileEntry objects for matching files.
  */
-export async function filesWithExtensions(options: Options, extensions: string[]): Promise<string[]> {
+export async function filesWithExtensions(options: Options, extensions: string[]): Promise<FileEntry[]> {
     const dir = options.src
     const stream = readdirp(dir, {
         fileFilter: (f) => !ignoreFileByName(options, f.basename, f.fullPath, extensions),
         directoryFilter: (d) => !ignoreDirectory(options, d.basename, d.fullPath),
-        lstat: true
+        lstat: true,
+        alwaysStat: true,
+        depth: options.recurse ? undefined : 0,
     })
-    const files: string[] = []
+    const files: FileEntry[] = []
     for await (const entry of stream) {
-        if (!shouldSkipFileIO(entry.fullPath)) {
-            files.push(entry.fullPath)
+        const content = readFileIfValid(entry.fullPath, entry.stats as fs.Stats)
+        if (content !== null) {
+            files.push({ path: entry.fullPath, content })
         }
     }
     return files

--- a/src/JsonUtils.ts
+++ b/src/JsonUtils.ts
@@ -1,15 +1,9 @@
 import * as fs from "node:fs"
+import { decodePos } from "./TscUtils"
 
 const STREAM_BUFFER_SIZE = 64 * 1024
 
-/**
- * Writes a Map<string, string> as a JSON object directly to a file using buffered I/O,
- * avoiding both the intermediate plain object from Object.fromEntries and the full JSON string.
- *
- * @param filePath The file path to write to.
- * @param map The map to serialize.
- */
-export function writeMapToJsonFile(filePath: string, map: Map<string, string>): void {
+function withBufferedWriter(filePath: string, fn: (write: (s: string) => void) => void): void {
     const fd = fs.openSync(filePath, "w")
     let buffer = ""
 
@@ -22,26 +16,39 @@ export function writeMapToJsonFile(filePath: string, map: Map<string, string>): 
 
     function write(s: string): void {
         buffer += s
-        if (buffer.length >= STREAM_BUFFER_SIZE) {
-            flush()
-        }
+        if (buffer.length >= STREAM_BUFFER_SIZE) flush()
     }
 
     try {
+        fn(write)
+        flush()
+    } finally {
+        fs.closeSync(fd)
+    }
+}
+
+/**
+ * Writes a Map<number, string> as a JSON object directly to a file using buffered I/O,
+ * avoiding both the intermediate plain object from Object.fromEntries and the full JSON string.
+ * Keys are decoded from packed (start, end) positions to "start:end" strings in the output.
+ *
+ * @param filePath The file path to write to.
+ * @param map The map to serialize.
+ */
+export function writeMapToJsonFile(filePath: string, map: Map<number, string>): void {
+    withBufferedWriter(filePath, (write) => {
         write("{")
         let first = true
         for (const [key, value] of map) {
             if (!first) write(",")
             first = false
-            write(JSON.stringify(key))
+            const [start, end] = decodePos(key)
+            write(`"${start}:${end}"`)
             write(":")
             write(JSON.stringify(value))
         }
         write("}")
-        flush()
-    } finally {
-        fs.closeSync(fd)
-    }
+    })
 }
 
 /**
@@ -55,92 +62,74 @@ export function writeMapToJsonFile(filePath: string, map: Map<string, string>): 
  * @param data The value to serialize.
  */
 export function writeJsonStreamCircular(filePath: string, data: any): void {
-    const fd = fs.openSync(filePath, "w")
-    let buffer = ""
     const seen = new WeakSet<object>()
 
-    function flush(): void {
-        if (buffer.length > 0) {
-            fs.writeSync(fd, buffer)
-            buffer = ""
-        }
-    }
-
-    function write(s: string): void {
-        buffer += s
-        if (buffer.length >= STREAM_BUFFER_SIZE) {
-            flush()
-        }
-    }
-
     function shouldSkip(v: any): boolean {
-        if (v === undefined || typeof v === "function" || typeof v === "symbol") return true
-        if (typeof v === "object" && v !== null && seen.has(v)) return true
-        return false
+        return v === undefined || typeof v === "function" || typeof v === "symbol" ||
+            (typeof v === "object" && v !== null && seen.has(v))
     }
 
-    function writeValue(value: any): void {
-        if (value === null) { write("null"); return }
-        switch (typeof value) {
-            case "string":
-                write(JSON.stringify(value))
-                return
-            case "number":
-                write(isFinite(value) ? String(value) : "null")
-                return
-            case "boolean":
-                write(value ? "true" : "false")
-                return
-            case "object":
-                seen.add(value)
-                if (typeof value.toJSON === "function") {
-                    writeValue(value.toJSON())
+    withBufferedWriter(filePath, (write) => {
+        function writeValue(value: any): void {
+            if (value === null) { write("null"); return }
+            switch (typeof value) {
+                case "string":
+                    write(JSON.stringify(value))
                     return
-                }
-                if (Array.isArray(value)) {
-                    writeArray(value)
-                } else {
-                    writeObject(value)
-                }
-                return
-            default:
-                write("null")
-                return
-        }
-    }
-
-    function writeArray(arr: any[]): void {
-        write("[")
-        for (let i = 0; i < arr.length; i++) {
-            if (i > 0) write(",")
-            if (shouldSkip(arr[i])) {
-                write("null")
-            } else {
-                writeValue(arr[i])
+                case "number":
+                    write(isFinite(value) ? String(value) : "null")
+                    return
+                case "boolean":
+                    write(value ? "true" : "false")
+                    return
+                case "object":
+                    seen.add(value)
+                    if (typeof value.toJSON === "function") {
+                        const resolved = value.toJSON()
+                        if (typeof resolved === "object" && resolved !== null) seen.add(resolved)
+                        writeValue(resolved)
+                        return
+                    }
+                    if (Array.isArray(value)) {
+                        writeArray(value)
+                    } else {
+                        writeObject(value)
+                    }
+                    return
+                default:
+                    write("null")
+                    return
             }
         }
-        write("]")
-    }
 
-    function writeObject(obj: object): void {
-        write("{")
-        let first = true
-        for (const key of Object.keys(obj)) {
-            const v = (obj as any)[key]
-            if (shouldSkip(v)) continue
-            if (!first) write(",")
-            first = false
-            write(JSON.stringify(key))
-            write(":")
-            writeValue(v)
+        function writeArray(arr: any[]): void {
+            write("[")
+            for (let i = 0; i < arr.length; i++) {
+                if (i > 0) write(",")
+                if (shouldSkip(arr[i])) {
+                    write("null")
+                } else {
+                    writeValue(arr[i])
+                }
+            }
+            write("]")
         }
-        write("}")
-    }
 
-    try {
+        function writeObject(obj: object): void {
+            write("{")
+            let first = true
+            for (const key of Object.keys(obj)) {
+                const v = (obj as any)[key]
+                if (shouldSkip(v)) continue
+                if (!first) write(",")
+                first = false
+                write(JSON.stringify(key))
+                write(":")
+                writeValue(v)
+            }
+            write("}")
+        }
+
         writeValue(data)
-        flush()
-    } finally {
-        fs.closeSync(fd)
-    }
+    })
 }

--- a/src/TscUtils.ts
+++ b/src/TscUtils.ts
@@ -2,7 +2,24 @@ import * as Defaults from "./Defaults"
 
 import tsc from "typescript"
 
-export type TypeMap = Map<string, string>
+export type TypeMap = Map<number, string>
+
+// Packs (start, end) positions into a single number key.
+// Using a Map<number, string> avoids per-entry string allocation; at the scale of a full
+// TypeMap (one entry per AST node), packed doubles (~12B each) are ~4x cheaper than
+// equivalent "start:end" strings (~50B each) and avoid the N inner-Map overhead of a
+// nested Map<number, Map<number, string>>.
+//
+// POS_SHIFT = 2^26: supports positions up to 64MB per file.
+// The 5MB file size guard (MAX_FILE_SIZE_BYTES) ensures this assumption holds.
+const POS_SHIFT = 0x4000000
+export function encodePos(start: number, end: number): number {
+    return start * POS_SHIFT + end
+}
+export function decodePos(key: number): [number, number] {
+    const start = Math.floor(key / POS_SHIFT)
+    return [start, key - start * POS_SHIFT]
+}
 
 /**
  * Utility class for working with the TypeScript compiler API.
@@ -36,7 +53,7 @@ export default class TscUtils {
      * @returns A `TypeMap` mapping node positions to their inferred type strings.
      */
     typeMapForFile(file: string): TypeMap {
-        let addType: (node: tsc.Node) => void = (node: tsc.Node): void => {
+        const addType: (node: tsc.Node) => void = (node: tsc.Node): void => {
             if (!this.shouldResolveType(node)) return
             let typeStr
             if (this.isSignatureDeclaration(node)) {
@@ -45,22 +62,19 @@ export default class TscUtils {
                 typeStr = this.safeTypeToString(returnType)
             } else if (tsc.isFunctionLike(node)) {
                 const funcType: tsc.Type = this.typeChecker.getTypeAtLocation(node)
-                const funcSignature: tsc.Signature = this.typeChecker.getSignaturesOfType(funcType, tsc.SignatureKind.Call)[0]
-                if (funcSignature) {
-                    typeStr = this.safeTypeToString(funcSignature.getReturnType())
-                } else {
-                    typeStr = this.safeTypeToString(this.typeChecker.getTypeAtLocation(node))
-                }
+                const funcSignature: tsc.Signature  = this.typeChecker.getSignaturesOfType(funcType, tsc.SignatureKind.Call)[0]
+                typeStr = funcSignature
+                    ? this.safeTypeToString(funcSignature.getReturnType())
+                    : this.safeTypeToString(funcType)
             } else {
                 typeStr = this.safeTypeToString(this.typeChecker.getTypeAtLocation(node))
             }
             if (typeStr !== Defaults.ANY) {
-                const pos = `${node.getStart()}:${node.getEnd()}`
-                seenTypes.set(pos, typeStr)
+                seenTypes.set(encodePos(node.getStart(), node.getEnd()), typeStr)
             }
         }
 
-        const seenTypes = new Map<string, string>()
+        const seenTypes = new Map<number, string>()
         this.forEachNode(this.program.getSourceFile(file)!, addType)
         return seenTypes
     }

--- a/test/astgen.test.ts
+++ b/test/astgen.test.ts
@@ -4,16 +4,16 @@ import * as fs from "node:fs"
 import start from "../src/AstGenerator"
 import Options from "../src/Options"
 
-async function setupTestFixture(code: string,
-                                filename: string,
-                                options: Object,
-                                testFunc: (dir: string, testFile: string) => void,
-                                excludeFiles: (dir: string, testFile: string) => string[] = (): string[] => {
-                                    return []
-                                }) {
+async function setupTestFixture(
+    code: string,
+    filename: string,
+    options: Partial<Options>,
+    testFunc: (dir: string, testFile: string) => void,
+    excludeFiles: (dir: string, testFile: string) => string[] = () => [],
+) {
     const tmpDir: string = fs.mkdtempSync(path.join(os.tmpdir(), "astgen-tests"))
     const testFile: string = path.join(tmpDir, filename)
-    if (!fs.existsSync((path.dirname(testFile)))) {
+    if (!fs.existsSync(path.dirname(testFile))) {
         fs.mkdirSync(path.dirname(testFile), {recursive: true})
     }
     fs.writeFileSync(testFile, code)
@@ -31,23 +31,23 @@ async function setupTestFixture(code: string,
     fs.rmSync(tmpDir, {recursive: true})
 }
 
-
-describe('astgen basic functionality', () => {
-    it('should parse another js file correctly', async () => {
+describe("astgen basic functionality", () => {
+    it("should parse another js file correctly", async () => {
         const code = `const somedata = require('../../package.json');
           const foo = "Something";
           const bar = {
             foo
           };
           exports.foo = bar.foo;
-          module.exports = bar;`;
+          module.exports = bar;`
 
         await setupTestFixture(code, "main.js", {}, (tmpDir: string, testFile: string) => {
             const resultAst = fs.readFileSync(path.join(tmpDir, "ast_out", "main.js.json")).toString()
             expect(resultAst).toContain("\"fullName\":\"" + testFile.replaceAll("\\", "\\\\") + "\"")
             expect(resultAst).toContain("\"relativeName\":\"main.js\"")
             const resultTypes = fs.readFileSync(path.join(tmpDir, "ast_out", "main.js.typemap")).toString()
-            expect(resultTypes).toEqual("{" +
+            expect(resultTypes).toEqual(
+                "{" +
                 "\"17:24\":\"Require\"," +
                 "\"25:45\":\"string\"," +
                 "\"64:67\":\"string\"," +
@@ -67,11 +67,12 @@ describe('astgen basic functionality', () => {
                 "\"179:193\":\"{ foo: any; }\"," +
                 "\"196:199\":\"{ foo: string; }\"," +
                 "\"179:199\":\"{ foo: any; }\"" +
-                "}")
+                "}"
+            )
         })
     })
 
-    it('should parse a simple js file correctly', async () => {
+    it("should parse a simple js file correctly", async () => {
         const code = "console.log(\"Hello, world!\");"
 
         await setupTestFixture(code, "main.js", {}, (tmpDir: string, testFile: string) => {
@@ -79,139 +80,121 @@ describe('astgen basic functionality', () => {
             expect(resultAst).toContain("\"fullName\":\"" + testFile.replaceAll("\\", "\\\\") + "\"")
             expect(resultAst).toContain("\"relativeName\":\"main.js\"")
             const resultTypes = fs.readFileSync(path.join(tmpDir, "ast_out", "main.js.typemap")).toString()
-            expect(resultTypes).toEqual("{" +
+            expect(resultTypes).toEqual(
+                "{" +
                 "\"0:7\":\"Console\"," +
                 "\"8:11\":\"{ (...data: any[]): void; (message?: any, ...optionalParams: any[]): void; }\"," +
                 "\"0:11\":\"{ (...data: any[]): void; (message?: any, ...optionalParams: any[]): void; }\"," +
                 "\"12:27\":\"string\",\"0:28\":\"void\"" +
-                "}")
+                "}"
+            )
         })
     })
 
-    it('should exclude files by relative file path correctly', async () => {
+    it("should exclude files by relative file path correctly", async () => {
         const code = "console.log(\"Hello, world!\");"
-        const config = {
-            tsTypes: false,
-            "exclude-file": ["main.js"]
-        }
-        await setupTestFixture(code, "main.js", config, (tmpDir: string, _: string) => {
+        const config = {tsTypes: false, "exclude-file": ["main.js"]}
+
+        await setupTestFixture(code, "main.js", config, (tmpDir: string, _) => {
             expect(fs.existsSync(path.join(tmpDir, "ast_out", "main.js.json"))).toBeFalsy()
         })
     })
 
-    it('should exclude files by absolute file path correctly', async () => {
+    it("should exclude files by absolute file path correctly", async () => {
         const code = "console.log(\"Hello, world!\");"
-        const config = {tsTypes: false}
 
-        await setupTestFixture(code, "main.js", config, (tmpDir: string, _: string) => {
+        await setupTestFixture(code, "main.js", {tsTypes: false}, (tmpDir: string, _) => {
             expect(fs.existsSync(path.join(tmpDir, "ast_out", "main.js.json"))).toBeFalsy()
-        }, (_, testFile): string[] => {
-            return [testFile]
-        })
+        }, (_, testFile) => [testFile])
     })
 
-    it('should exclude files by relative file path with dir correctly', async () => {
+    it("should exclude files by relative file path with dir correctly", async () => {
         const code = "console.log(\"Hello, world!\");"
-        const config = {
-            tsTypes: false,
-            "exclude-file": [path.join("src", "main.js")]
-        }
-        await setupTestFixture(code, "src/main.js", config, (tmpDir: string, _: string) => {
+        const config = {tsTypes: false, "exclude-file": [path.join("src", "main.js")]}
+
+        await setupTestFixture(code, "src/main.js", config, (tmpDir: string, _) => {
             expect(fs.existsSync(path.join(tmpDir, "ast_out", "src", "main.js.json"))).toBeFalsy()
         })
     })
 
-    it('should exclude files by relative dir path correctly', async () => {
+    it("should exclude files by relative dir path correctly", async () => {
         const code = "console.log(\"Hello, world!\");"
-        const config = {
-            tsTypes: false,
-            "exclude-file": ["src"]
-        }
-        await setupTestFixture(code, "src/main.js", config, (tmpDir: string, _: string) => {
+        const config = {tsTypes: false, "exclude-file": ["src"]}
+
+        await setupTestFixture(code, "src/main.js", config, (tmpDir: string, _) => {
             expect(fs.existsSync(path.join(tmpDir, "ast_out", "src", "main.js.json"))).toBeFalsy()
         })
     })
 
-    it('should exclude files by absolute dir path correctly', async () => {
+    it("should exclude files by absolute dir path correctly", async () => {
         const code = "console.log(\"Hello, world!\");"
-        const config = {tsTypes: false}
 
-        await setupTestFixture(code, "src/main.js", config, (tmpDir: string, _: string) => {
+        await setupTestFixture(code, "src/main.js", {tsTypes: false}, (tmpDir: string, _) => {
             expect(fs.existsSync(path.join(tmpDir, "ast_out", "src", "main.js.json"))).toBeFalsy()
-        }, (tmpDir, _): string[] => {
-            return [path.join(tmpDir, "src")]
-        })
+        }, (tmpDir, _) => [path.join(tmpDir, "src")])
     })
 
-    it('should exclude files by regex correctly', async () => {
+    it("should exclude files by regex correctly", async () => {
         const code = "console.log(\"Hello, world!\");"
-        const config = {
-            tsTypes: false,
-            "exclude-file": [],
-            "exclude-regex": new RegExp(".*main.*", "i")
-        }
-        await setupTestFixture(code, "main.js", config, (tmpDir: string, _: string) => {
+        const config = {tsTypes: false, "exclude-file": [], "exclude-regex": /.*main.*/i}
+
+        await setupTestFixture(code, "main.js", config, (tmpDir: string, _) => {
             expect(fs.existsSync(path.join(tmpDir, "ast_out", "main.js.json"))).toBeFalsy()
         })
     })
 
-    it('should skip files with more than 50000 lines', async () => {
-        const lines = Array(50001).fill('const x = 1;').join('\n')
+    it("should skip files with more than 50000 lines", async () => {
+        const code = Array(50001).fill("const x = 1;").join("\n")
 
-        await setupTestFixture(lines, "huge.ts", {}, (tmpDir: string, testFile: string) => {
-            const outFile = path.join(tmpDir, "ast_out", "huge.ts.json")
-            expect(fs.existsSync(outFile)).toBe(false)
+        await setupTestFixture(code, "huge.ts", {}, (tmpDir: string, _) => {
+            expect(fs.existsSync(path.join(tmpDir, "ast_out", "huge.ts.json"))).toBe(false)
         })
     })
 
-    it('should skip files with a line longer than 10000 bytes', async () => {
-        const longLine = 'const x = "' + 'a'.repeat(10001) + '";'
+    it("should skip files with a line longer than 10000 bytes", async () => {
+        const longLine = "const x = \"" + "a".repeat(10001) + "\";"
         const code = `const y = 1;\n${longLine}\nconst z = 2;`
 
-        await setupTestFixture(code, "longline.ts", {}, (tmpDir: string, testFile: string) => {
-            const outFile = path.join(tmpDir, "ast_out", "longline.ts.json")
-            expect(fs.existsSync(outFile)).toBe(false)
+        await setupTestFixture(code, "longline.ts", {}, (tmpDir: string, _) => {
+            expect(fs.existsSync(path.join(tmpDir, "ast_out", "longline.ts.json"))).toBe(false)
         })
     })
 
-    it('should skip files larger than 5MB', async () => {
-        const bigContent = 'x'.repeat(5 * 1024 * 1024 + 1)
+    it("should skip files larger than 5MB", async () => {
+        const code = "x".repeat(5 * 1024 * 1024 + 1)
 
-        await setupTestFixture(bigContent, "huge.ts", {}, (tmpDir: string, testFile: string) => {
-            const outFile = path.join(tmpDir, "ast_out", "huge.ts.json")
-            expect(fs.existsSync(outFile)).toBe(false)
+        await setupTestFixture(code, "huge.ts", {}, (tmpDir: string, _) => {
+            expect(fs.existsSync(path.join(tmpDir, "ast_out", "huge.ts.json"))).toBe(false)
         })
     })
 
-    it('should process files just under all size thresholds', async () => {
-        const normalLine = 'const x = "' + 'a'.repeat(9980) + '";'
+    it("should process files just under all size thresholds", async () => {
+        const normalLine = "const x = \"" + "a".repeat(9980) + "\";"
         const code = `${normalLine}\nconst y = 1;`
 
-        await setupTestFixture(code, "borderline.ts", {}, (tmpDir: string, testFile: string) => {
-            const outFile = path.join(tmpDir, "ast_out", "borderline.ts.json")
-            expect(fs.existsSync(outFile)).toBe(true)
+        await setupTestFixture(code, "borderline.ts", {}, (tmpDir: string, _) => {
+            expect(fs.existsSync(path.join(tmpDir, "ast_out", "borderline.ts.json"))).toBe(true)
         })
     })
 
-    it('should produce bounded-length type strings for complex union types', async () => {
+    it("should produce bounded-length type strings for complex union types", async () => {
         // Validates that the pipeline produces short type strings for complex types.
         // TypeScript's own truncation (~160 chars) handles this; the 500-char guard in
         // safeTypeToString is a defense-in-depth layer for future TS version changes.
         const code = `
-type Long = "a1"|"a2"|"a3"|"a4"|"a5"|"a6"|"a7"|"a8"|"a9"|"a10"|
-            "b1"|"b2"|"b3"|"b4"|"b5"|"b6"|"b7"|"b8"|"b9"|"b10"|
-            "c1"|"c2"|"c3"|"c4"|"c5"|"c6"|"c7"|"c8"|"c9"|"c10"|
-            "d1"|"d2"|"d3"|"d4"|"d5"|"d6"|"d7"|"d8"|"d9"|"d10"|
-            "e1"|"e2"|"e3"|"e4"|"e5"|"e6"|"e7"|"e8"|"e9"|"e10"|
-            "f1"|"f2"|"f3"|"f4"|"f5"|"f6"|"f7"|"f8"|"f9"|"f10";
-const x: Long = "a1";
+            type Long = "a1"|"a2"|"a3"|"a4"|"a5"|"a6"|"a7"|"a8"|"a9"|"a10"|
+                        "b1"|"b2"|"b3"|"b4"|"b5"|"b6"|"b7"|"b8"|"b9"|"b10"|
+                        "c1"|"c2"|"c3"|"c4"|"c5"|"c6"|"c7"|"c8"|"c9"|"c10"|
+                        "d1"|"d2"|"d3"|"d4"|"d5"|"d6"|"d7"|"d8"|"d9"|"d10"|
+                        "e1"|"e2"|"e3"|"e4"|"e5"|"e6"|"e7"|"e8"|"e9"|"e10"|
+                        "f1"|"f2"|"f3"|"f4"|"f5"|"f6"|"f7"|"f8"|"f9"|"f10";
+            const x: Long = "a1";
 `
-        await setupTestFixture(code, "main.ts", {tsTypes: true}, (tmpDir: string) => {
+        await setupTestFixture(code, "main.ts", {tsTypes: true}, (tmpDir: string, _) => {
             const resultTypes = fs.readFileSync(path.join(tmpDir, "ast_out", "main.ts.typemap")).toString()
             const parsed = JSON.parse(resultTypes)
             const values = Object.values(parsed) as string[]
-            expect(values.every(v => (v as string).length <= 500)).toBe(true)
+            expect(values.every(v => v.length <= 500)).toBe(true)
         })
     })
-
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -696,13 +696,6 @@
     expect "^30.0.0"
     pretty-format "^30.0.0"
 
-"@types/n-readlines@^1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@types/n-readlines/-/n-readlines-1.0.6.tgz#8c03c9b1a4925d847ccf55c354fc86cbe556acc6"
-  integrity sha512-0kCJ/bVdHl0yxNYbiGTInj8BPqVLMiUp4gn4zfyYJgKn0iQKiJ+mNGCJj2rFLupOrZ5y/W5l13YhOZ8jYG9DIA==
-  dependencies:
-    "@types/node" "*"
-
 "@types/node@*":
   version "25.0.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-25.0.10.tgz#4864459c3c9459376b8b75fd051315071c8213e7"
@@ -1290,10 +1283,10 @@ eastasianwidth@^0.2.0:
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
-effect@^3.19.14:
-  version "3.19.14"
-  resolved "https://registry.yarnpkg.com/effect/-/effect-3.19.14.tgz#a11ef0ce0feddbddafa55155b21fd8827ae8037e"
-  integrity sha512-3vwdq0zlvQOxXzXNKRIPKTqZNMyGCdaFUBfMPqpsyzZDre67kgC1EEHDV4EoQTovJ4w5fmJW756f86kkuz7WFA==
+effect@^3.21.0:
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/effect/-/effect-3.21.0.tgz#ce222ce8f785b9e63f104b9a4ead985e7965f2c0"
+  integrity sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==
   dependencies:
     "@standard-schema/spec" "^1.0.0"
     fast-check "^3.23.1"
@@ -2230,11 +2223,6 @@ multistream@^4.1.0:
   dependencies:
     once "^1.4.0"
     readable-stream "^3.6.0"
-
-n-readlines@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/n-readlines/-/n-readlines-1.0.3.tgz#f1fc62c31fc214de7fe8bd3f168e3910c25ff3ec"
-  integrity sha512-kdrBSkcwgcTWI+e9Ag4Vke5pGoOJm/8hnAn7vHC8nHXyyiUgZht+J9EmGhlAWIFZuDvOq0F2SpCPCR/LBkq7OA==
 
 napi-build-utils@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- TscUtils: pack (start,end) into a single number key for TypeMap instead of allocating a "start:end" string per node (~4x smaller keys)
- FileUtils: use readdirp entry.stats to avoid redundant statSync; read file once and return content with each FileEntry, eliminating the double-read between the content guard and the parser; replace nReadlines + split with a single index-scan (no array alloc, early exit preserved); implement --recurse flag via readdirp depth
- AstGenerator: deduplicate mkdirSync calls per output directory via a Set; fall back to JS/TS processing in createXAst instead of exit
- JsonUtils: extract withBufferedWriter to eliminate duplicated fd/buffer/flush boilerplate; fix toJSON result not tracked in seen
- Regression harness: run each binary from its own build directory so Node resolves node_modules correctly when dependencies change
- Tests: Partial<Options>, double quotes, unused param cleanup